### PR TITLE
ERD 작성 내용에 맞춘 엔티티 클래스 생성

### DIFF
--- a/src/main/java/com/core/back9/common/config/DemoConfig.java
+++ b/src/main/java/com/core/back9/common/config/DemoConfig.java
@@ -1,0 +1,4 @@
+package com.core.back9.common.config;
+
+public class DemoConfig {
+}

--- a/src/main/java/com/core/back9/common/constant/SignType.java
+++ b/src/main/java/com/core/back9/common/constant/SignType.java
@@ -1,0 +1,4 @@
+package com.core.back9.common.constant;
+
+public enum SignType {
+}

--- a/src/main/java/com/core/back9/common/constant/Status.java
+++ b/src/main/java/com/core/back9/common/constant/Status.java
@@ -1,0 +1,4 @@
+package com.core.back9.common.constant;
+
+public enum Status {
+}

--- a/src/main/java/com/core/back9/controller/DemoController.java
+++ b/src/main/java/com/core/back9/controller/DemoController.java
@@ -1,0 +1,4 @@
+package com.core.back9.controller;
+
+public class DemoController {
+}

--- a/src/main/java/com/core/back9/entity/Buildings.java
+++ b/src/main/java/com/core/back9/entity/Buildings.java
@@ -1,0 +1,31 @@
+package com.core.back9.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "buildings")
+public class Buildings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String address;
+
+    @Column
+    private String zipCode;
+
+    @Builder
+    private Buildings(String address, String zipCode) {
+        this.address = address;
+        this.zipCode = zipCode;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/ComplaintScores.java
+++ b/src/main/java/com/core/back9/entity/ComplaintScores.java
@@ -1,0 +1,35 @@
+package com.core.back9.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "complaint_scores")
+public class ComplaintScores {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "score", nullable = false)
+    private int score;
+
+    @Column(name = "comment", nullable = false)
+    private String comment;
+
+    @Column(name = "bookmark")
+    private boolean bookmark;
+
+    @Builder
+    private ComplaintScores(int score, String comment, boolean bookmark) {
+        this.score = score;
+        this.comment = comment;
+        this.bookmark = bookmark;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/Contracts.java
+++ b/src/main/java/com/core/back9/entity/Contracts.java
@@ -1,0 +1,47 @@
+package com.core.back9.entity;
+
+import com.core.back9.entity.constant.ContractStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "contracts")
+public class Contracts {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "check_out", nullable = false)
+    private LocalDate checkOut;
+
+    @Column(name = "rental_price", nullable = false)
+    private Long rentalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contract_status", nullable = false)
+    private ContractStatus contractStatus;
+
+    @Builder
+    private Contracts(LocalDate startDate, LocalDate endDate, LocalDate checkOut, Long rentalPrice, ContractStatus contractStatus) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.checkOut = checkOut;
+        this.rentalPrice = rentalPrice;
+        this.contractStatus = contractStatus;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/FacilityScores.java
+++ b/src/main/java/com/core/back9/entity/FacilityScores.java
@@ -1,0 +1,35 @@
+package com.core.back9.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "facility_scores")
+public class FacilityScores {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "score", nullable = false)
+    private int score;
+
+    @Column(name = "comment", nullable = false)
+    private String comment;
+
+    @Column(name = "bookmark")
+    private boolean bookmark;
+
+    @Builder
+    private FacilityScores(int score, String comment, boolean bookmark) {
+        this.score = score;
+        this.comment = comment;
+        this.bookmark = bookmark;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/ManagementScores.java
+++ b/src/main/java/com/core/back9/entity/ManagementScores.java
@@ -1,0 +1,35 @@
+package com.core.back9.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "management_scores")
+public class ManagementScores {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "score", nullable = false)
+    private int score;
+
+    @Column(name = "comment", nullable = false)
+    private String comment;
+
+    @Column(name = "bookmark")
+    private boolean bookmark;
+
+    @Builder
+    private ManagementScores(int score, String comment, boolean bookmark) {
+        this.score = score;
+        this.comment = comment;
+        this.bookmark = bookmark;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/Members.java
+++ b/src/main/java/com/core/back9/entity/Members.java
@@ -1,0 +1,57 @@
+package com.core.back9.entity;
+
+import com.core.back9.common.constant.SignType;
+import com.core.back9.common.constant.Status;
+import com.core.back9.entity.constant.Role;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "members") // 향후 platform 로그인 고려 시 index 추가해 검색속도 높이는 것도 고려해보면 좋을 듯함
+public class Members {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email")
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private Role role;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private Status status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sign_type")
+    private SignType signType;
+
+    @Column(name = "firebase_uid")
+    private String firebaseUid; // 즉시 적용여부가 확실치 않아 nullable = true로 남겨두었음
+
+    @Column(name = "firebase_fcm_token")
+    private String firebaseFcmToken; // 즉시 적용여부가 확실치 않아 nullable = true로 남겨두었음
+
+    @Builder
+    private Members(String email, Role role, String phoneNumber, Status status, SignType signType, String firebaseUid, String firebaseFcmToken) {
+        this.email = email;
+        this.role = role;
+        this.phoneNumber = phoneNumber;
+        this.status = status;
+        this.signType = signType;
+        this.firebaseUid = firebaseUid;
+        this.firebaseFcmToken = firebaseFcmToken;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/Rooms.java
+++ b/src/main/java/com/core/back9/entity/Rooms.java
@@ -1,0 +1,45 @@
+package com.core.back9.entity;
+
+import com.core.back9.entity.constant.RoomStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "rooms")
+public class Rooms {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "floor")
+    private String floor;
+
+    @Column(name = "area")
+    private float area; // 건물 면적(제곱 미터)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "room_status")
+    private RoomStatus roomStatus;
+
+    @Column(name = "rating")
+    private float rating;
+
+    @Builder
+    private Rooms(String name, String floor, float area, RoomStatus roomStatus, float rating) {
+        this.name = name;
+        this.floor = floor;
+        this.area = area;
+        this.roomStatus = roomStatus;
+        this.rating = rating;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/Settings.java
+++ b/src/main/java/com/core/back9/entity/Settings.java
@@ -1,0 +1,31 @@
+package com.core.back9.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "settings")
+public class Settings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "Score_toggle")
+    private boolean ScoreToggle;
+
+    @Column(name = "message")
+    private String message;
+
+    @Builder
+    private Settings(boolean scoreToggle, String message) {
+        ScoreToggle = scoreToggle;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/Tenants.java
+++ b/src/main/java/com/core/back9/entity/Tenants.java
@@ -1,0 +1,27 @@
+package com.core.back9.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "tenants")
+public class Tenants {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "company_number")
+    private String companyNumber;
+
+    @Builder
+    private Tenants(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+}

--- a/src/main/java/com/core/back9/entity/constant/ContractStatus.java
+++ b/src/main/java/com/core/back9/entity/constant/ContractStatus.java
@@ -1,0 +1,4 @@
+package com.core.back9.entity.constant;
+
+public enum ContractStatus {
+}

--- a/src/main/java/com/core/back9/entity/constant/Role.java
+++ b/src/main/java/com/core/back9/entity/constant/Role.java
@@ -1,0 +1,4 @@
+package com.core.back9.entity.constant;
+
+public enum Role {
+}

--- a/src/main/java/com/core/back9/entity/constant/RoomStatus.java
+++ b/src/main/java/com/core/back9/entity/constant/RoomStatus.java
@@ -1,0 +1,4 @@
+package com.core.back9.entity.constant;
+
+public enum RoomStatus {
+}

--- a/src/main/java/com/core/back9/repository/DemoRepository.java
+++ b/src/main/java/com/core/back9/repository/DemoRepository.java
@@ -1,0 +1,4 @@
+package com.core.back9.repository;
+
+public interface DemoRepository {
+}

--- a/src/main/java/com/core/back9/service/DemoService.java
+++ b/src/main/java/com/core/back9/service/DemoService.java
@@ -1,0 +1,4 @@
+package com.core.back9.service;
+
+public class DemoService {
+}

--- a/src/main/java/com/core/back9/test/TestClass.java
+++ b/src/main/java/com/core/back9/test/TestClass.java
@@ -1,4 +1,0 @@
-package com.core.back9.test;
-
-public class TestClass {
-}


### PR DESCRIPTION
## 📝작업 내용
> ERD 작성 내용에 맞춘 엔티티 클래스 생성
연관관계 연결 미완성 상태
테이블 및 필드명은 기본적으로 작성되는 DB명명 정책에 따라 작성

## #️⃣연관된 이슈
> closed : #2 
## 💬리뷰 요구사항(선택)

> 기본적인 생성자는 @AllArgsConstructor 클래스 단위 부착에 따른 필드 보안 취약점을 고려해 직접 작성 후 private 처리하였습니다.
생성자 부착 @Builder 방식을 고려해 외부에서 필드에 대한 접근을 열어놓았습니다.

