### PR TITLE
빌딩-호실 연관관계 기능 구현

### DIFF
--- a/src/main/java/com/core/back9/controller/RoomController.java
+++ b/src/main/java/com/core/back9/controller/RoomController.java
@@ -43,7 +43,7 @@ public class RoomController {
 	  @PathVariable Long buildingId,
 	  @PathVariable Long roomId
 	) {
-		return ResponseEntity.ok(roomService.delete(roomId));
+		return ResponseEntity.ok(roomService.delete(buildingId, roomId));
 	}
 
 	@GetMapping("")

--- a/src/main/java/com/core/back9/dto/BuildingDTO.java
+++ b/src/main/java/com/core/back9/dto/BuildingDTO.java
@@ -1,9 +1,7 @@
 package com.core.back9.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 
@@ -35,6 +33,7 @@ public class BuildingDTO {
 	@NoArgsConstructor
 	@Builder
 	@Getter
+	@Setter
 	public static class Info {
 		private Long id;
 		private String name;
@@ -42,6 +41,7 @@ public class BuildingDTO {
 		private String zipCode;
 		private LocalDateTime createdAt;
 		private LocalDateTime updatedAt;
+		private Page<RoomDTO.Info> roomPage;
 	}
 
 }

--- a/src/main/java/com/core/back9/entity/Building.java
+++ b/src/main/java/com/core/back9/entity/Building.java
@@ -9,6 +9,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -28,6 +31,13 @@ public class Building extends BaseEntity {
 	@Column
 	private Status status;
 
+	@OneToMany(
+	  cascade = CascadeType.REMOVE,
+	  fetch = FetchType.LAZY,
+	  orphanRemoval = true
+	)
+	private final List<Room> roomList = new ArrayList<>();
+
 	@Builder
 	private Building(String name, String address, String zipCode) {
 		this.name = name;
@@ -44,6 +54,14 @@ public class Building extends BaseEntity {
 
 	public void delete() {
 		this.status = Status.UNREGISTER;
+	}
+
+	public void addRoom(Room room) {
+		this.roomList.add(room);
+	}
+
+	public void removeRoom(Room room) {
+		this.roomList.remove(room);
 	}
 
 }

--- a/src/main/java/com/core/back9/entity/Room.java
+++ b/src/main/java/com/core/back9/entity/Room.java
@@ -26,7 +26,7 @@ public class Room extends BaseEntity {
 	private float area; // 건물 면적(제곱 미터)
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "usage")
+	@Column(name = "room_usage")
 	private Usage usage; // 호실의 용도를 구분하는 Enum
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/core/back9/mapper/BuildingMapper.java
+++ b/src/main/java/com/core/back9/mapper/BuildingMapper.java
@@ -1,22 +1,42 @@
 package com.core.back9.mapper;
 
 import com.core.back9.dto.BuildingDTO;
+import com.core.back9.dto.RoomDTO;
 import com.core.back9.entity.Building;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingConstants;
-import org.mapstruct.ReportingPolicy;
+import com.core.back9.entity.Room;
+import org.mapstruct.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 @Mapper(
   componentModel = MappingConstants.ComponentModel.SPRING,
   unmappedSourcePolicy = ReportingPolicy.IGNORE,
-  unmappedTargetPolicy = ReportingPolicy.IGNORE
+  unmappedTargetPolicy = ReportingPolicy.IGNORE,
+  uses = RoomMapper.class
 )
 public interface BuildingMapper {
+
+	@Autowired
+	RoomMapper roomMapper = new RoomMapperImpl();
 
 	Building toEntity(BuildingDTO.Request request);
 
 	BuildingDTO.Response toResponse(Building building);
 
 	BuildingDTO.Info toInfo(Building building);
+
+	@Mapping(
+	  target = "roomPage",
+	  expression = "java(toRoomPage(building.getRoomList(), pageable))"
+	)
+	BuildingDTO.Info toInfo(Building building, Pageable pageable);
+
+	@Named("toRoomPage")
+	default Page<RoomDTO.Info> toRoomPage(List<Room> roomList, Pageable pageable) {
+		return roomMapper.toInfoPage(roomList, pageable);
+	}
 
 }

--- a/src/main/java/com/core/back9/mapper/RoomMapper.java
+++ b/src/main/java/com/core/back9/mapper/RoomMapper.java
@@ -1,10 +1,14 @@
 package com.core.back9.mapper;
 
 import com.core.back9.dto.RoomDTO;
+import com.core.back9.entity.Building;
 import com.core.back9.entity.Room;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingConstants;
-import org.mapstruct.ReportingPolicy;
+import org.mapstruct.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 @Mapper(
   componentModel = MappingConstants.ComponentModel.SPRING,
@@ -13,10 +17,21 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface RoomMapper {
 
-	Room toEntity(Long buildingId, RoomDTO.Request request);
+	@Mapping(target = "building", expression = "java(building)")
+	Room toEntity(@Context Building building, RoomDTO.Request request);
 
 	RoomDTO.Response toResponse(Room room);
 
 	RoomDTO.Info toInfo(Room room);
+
+	List<RoomDTO.Info> toInfoList(List<Room> rooms);
+
+	@Named("toInfoPage")
+	default Page<RoomDTO.Info> toInfoPage(List<Room> roomList, Pageable pageable) {
+		int start = (int) pageable.getOffset();
+		int end = Math.min((start + pageable.getPageSize()), roomList.size());
+		List<RoomDTO.Info> dtoList = toInfoList(roomList.subList(start, end));
+		return new PageImpl<>(dtoList, pageable, roomList.size());
+	}
 
 }

--- a/src/main/java/com/core/back9/service/BuildingService.java
+++ b/src/main/java/com/core/back9/service/BuildingService.java
@@ -28,7 +28,7 @@ public class BuildingService {
 	@Transactional(readOnly = true)
 	public Page<BuildingDTO.Info> selectAll(Pageable pageable) {
 		return buildingRepository.findAllByStatus(Status.REGISTER, pageable)
-		  .map(buildingMapper::toInfo);
+		  .map(building -> buildingMapper.toInfo(building, pageable));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/core/back9/service/RoomService.java
+++ b/src/main/java/com/core/back9/service/RoomService.java
@@ -1,6 +1,7 @@
 package com.core.back9.service;
 
 import com.core.back9.dto.RoomDTO;
+import com.core.back9.entity.Building;
 import com.core.back9.entity.Room;
 import com.core.back9.entity.constant.Status;
 import com.core.back9.mapper.RoomMapper;
@@ -22,8 +23,10 @@ public class RoomService {
 	private final RoomMapper roomMapper;
 
 	public RoomDTO.Response create(Long buildingId, RoomDTO.Request request) {
-		Room newRoom = roomMapper.toEntity(buildingId, request);
+		Building validBuilding = buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
+		Room newRoom = roomMapper.toEntity(validBuilding, request);
 		Room savedRoom = roomRepository.save(newRoom);
+		validBuilding.addRoom(savedRoom);
 		return roomMapper.toResponse(savedRoom);
 	}
 
@@ -33,8 +36,10 @@ public class RoomService {
 		return roomMapper.toInfo(validRoom);
 	}
 
-	public boolean delete(Long roomId) {
+	public boolean delete(Long buildingId, Long roomId) {
+		Building validBuilding = buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
 		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(roomId, Status.REGISTER);
+		validBuilding.removeRoom(validRoom);
 		validRoom.delete();
 		return validRoom.getStatus() == Status.UNREGISTER;
 	}

--- a/src/main/resources/db/migration/V4__building-include-room.sql
+++ b/src/main/resources/db/migration/V4__building-include-room.sql
@@ -1,0 +1,20 @@
+CREATE TABLE buildings_room_list
+(
+    building_id  BIGINT NOT NULL,
+    room_list_id BIGINT NOT NULL
+);
+
+ALTER TABLE buildings_room_list
+    ADD CONSTRAINT uc_buildings_room_list_roomlist UNIQUE (room_list_id);
+
+ALTER TABLE buildings_room_list
+    ADD CONSTRAINT fk_buiroolis_on_building FOREIGN KEY (building_id) REFERENCES buildings (id);
+
+ALTER TABLE buildings_room_list
+    ADD CONSTRAINT fk_buiroolis_on_room FOREIGN KEY (room_list_id) REFERENCES rooms (id);
+
+ALTER TABLE rooms
+DROP COLUMN `usage`;
+
+ALTER TABLE rooms
+    ADD room_usage VARCHAR(255) NULL;

--- a/src/test/java/com/core/back9/controller/BuildingControllerTest.java
+++ b/src/test/java/com/core/back9/controller/BuildingControllerTest.java
@@ -1,6 +1,7 @@
 package com.core.back9.controller;
 
 import com.core.back9.dto.BuildingDTO;
+import com.core.back9.dto.RoomDTO;
 import com.core.back9.service.BuildingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,15 +69,18 @@ class BuildingControllerTest {
 		infoList = List.of(
 		  new BuildingDTO.Info(1L, "building1", "address1", "zipCode1",
 			LocalDateTime.of(2024, 3, 5, 13, 30, 0),
-			LocalDateTime.of(2024, 3, 5, 13, 30, 0)
+			LocalDateTime.of(2024, 3, 5, 13, 30, 0),
+			new PageImpl<>(List.of(RoomDTO.Info.builder().id(1L).name("building1 room1").build()))
 		  ),
 		  new BuildingDTO.Info(2L, "building2", "address2", "zipCode2",
 			LocalDateTime.of(2024, 4, 5, 14, 40, 0),
-			LocalDateTime.of(2024, 4, 5, 14, 40, 0)
+			LocalDateTime.of(2024, 4, 5, 14, 40, 0),
+			null
 		  ),
 		  new BuildingDTO.Info(3L, "building3", "address3", "zipCode3",
 			LocalDateTime.of(2024, 5, 5, 15, 50, 0),
-			LocalDateTime.of(2024, 5, 5, 15, 50, 0)
+			LocalDateTime.of(2024, 5, 5, 15, 50, 0),
+			null
 		  )
 		);
 	}

--- a/src/test/java/com/core/back9/controller/RoomControllerTest.java
+++ b/src/test/java/com/core/back9/controller/RoomControllerTest.java
@@ -119,13 +119,13 @@ class RoomControllerTest {
 	public void givenBuildingIdAndRoomIdWhenDeleteRoomThenSuccessResult() throws Exception {
 		long selectedBuildingId = 1L;
 		long deleteRoomId = 1L;
-		given(roomService.delete(anyLong())).willReturn(true);
+		given(roomService.delete(anyLong(), anyLong())).willReturn(true);
 
 		mockMvc.perform(delete("/api/buildings/" + selectedBuildingId + "/rooms/" + deleteRoomId))
 		  .andDo(print())
 		  .andExpect(status().isOk())
 		  .andExpect(content().string("true"));
-		verify(roomService).delete(anyLong());
+		verify(roomService).delete(anyLong(), anyLong());
 	}
 
 	@DisplayName("호실 전체 조회 성공")

--- a/src/test/java/com/core/back9/service/BuildingServiceTest.java
+++ b/src/test/java/com/core/back9/service/BuildingServiceTest.java
@@ -102,7 +102,7 @@ class BuildingServiceTest {
 		Page<Building> buildingPage = new PageImpl<>(List.of(building), pageable, 1);
 		Page<BuildingDTO.Info> buildingInfoPage = new PageImpl<>(List.of(info), pageable, 1);
 		given(buildingRepository.findAllByStatus(Status.REGISTER, pageable)).willReturn(buildingPage);
-		given(buildingMapper.toInfo(building)).willReturn(info);
+		given(buildingMapper.toInfo(building, pageable)).willReturn(info);
 
 		Page<BuildingDTO.Info> result = buildingService.selectAll(pageable);
 

--- a/src/test/java/com/core/back9/service/RoomServiceTest.java
+++ b/src/test/java/com/core/back9/service/RoomServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -106,14 +107,16 @@ class RoomServiceTest {
 		  .area(84F)
 		  .usage(Usage.OFFICES)
 		  .build();
-		given(roomMapper.toEntity(building.getId(), request)).willReturn(room);
+		given(buildingRepository.getValidBuildingWithIdOrThrow(building.getId(), Status.REGISTER)).willReturn(building);
+		given(roomMapper.toEntity(building, request)).willReturn(room);
 		given(roomRepository.save(room)).willReturn(savedRoom);
 		given(roomMapper.toResponse(savedRoom)).willReturn(response);
 
 		RoomDTO.Response result = roomService.create(building.getId(), request);
 
 		assertThat(result).isEqualTo(result);
-		verify(roomMapper).toEntity(building.getId(), request);
+		verify(buildingRepository).getValidBuildingWithIdOrThrow(building.getId(), Status.REGISTER);
+		verify(roomMapper).toEntity(building, request);
 		verify(roomRepository).save(room);
 		verify(roomMapper).toResponse(savedRoom);
 	}
@@ -143,12 +146,15 @@ class RoomServiceTest {
 	@DisplayName("호실 삭제 성공")
 	@Test
 	public void givenRoomIdWhenDeleteRoomThenSuccessResult() {
+		long selectedBuildingId = 1L;
 		long deleteId = 1L;
+		given(buildingRepository.getValidBuildingWithIdOrThrow(selectedBuildingId, Status.REGISTER)).willReturn(building);
 		given(roomRepository.getValidRoomWithIdOrThrow(deleteId, Status.REGISTER)).willReturn(room);
 
-		boolean result = roomService.delete(deleteId);
+		boolean result = roomService.delete(selectedBuildingId, deleteId);
 
 		assertThat(result).isTrue();
+		verify(buildingRepository).getValidBuildingWithIdOrThrow(selectedBuildingId, Status.REGISTER);
 		verify(roomRepository).getValidRoomWithIdOrThrow(deleteId, Status.REGISTER);
 	}
 


### PR DESCRIPTION
## 📝작업 내용
> 빌딩-호실 관계테이블 생성, 호실 용도 컬럼명 변경 DB migration
> 호실 등록 시 빌딩 지정
> 빌딩 조회 시 호실 데이터 포함

## #️⃣연관된 이슈
> closed : #45 

## 💬리뷰 요구사항(선택)
> 호실 등록 시 상위 빌딩의 아이디를 PathVariable로 받아서 아이디로 추가하려고 했던 부분을 매퍼 이슈로 인해 빌딩 객체로 추가하도록 변경했습니다.