### PR TITLE
호실 설정 기능 구현

### DIFF
--- a/src/main/java/com/core/back9/controller/BuildingController.java
+++ b/src/main/java/com/core/back9/controller/BuildingController.java
@@ -30,17 +30,21 @@ public class BuildingController {
 	}
 
 	@GetMapping("/{buildingId}")
-	public ResponseEntity<BuildingDTO.Info> getOne(@PathVariable Long buildingId) {
-		return ResponseEntity.ok(buildingService.selectOne(buildingId));
+	public ResponseEntity<BuildingDTO.Info> getOne(
+	  @PathVariable Long buildingId,
+	  Pageable pageable
+	) {
+		return ResponseEntity.ok(buildingService.selectOne(buildingId, pageable));
 	}
 
 	@PatchMapping("/{buildingId}")
 	public ResponseEntity<BuildingDTO.Info> modify(
 	  @PathVariable Long buildingId,
 	  @Valid
-	  @RequestBody BuildingDTO.Request request
+	  @RequestBody BuildingDTO.Request request,
+	  Pageable pageable
 	) {
-		return ResponseEntity.ok(buildingService.update(buildingId, request));
+		return ResponseEntity.ok(buildingService.update(buildingId, request, pageable));
 	}
 
 	@DeleteMapping("/{buildingId}")

--- a/src/main/java/com/core/back9/controller/RoomController.java
+++ b/src/main/java/com/core/back9/controller/RoomController.java
@@ -34,7 +34,7 @@ public class RoomController {
 	  @Valid
 	  @RequestBody RoomDTO.Request request
 	) {
-		return ResponseEntity.ok(roomService.update(roomId, request));
+		return ResponseEntity.ok(roomService.update(buildingId, roomId, request));
 	}
 
 	@DeleteMapping("/{roomId}")
@@ -61,7 +61,35 @@ public class RoomController {
 	  @PathVariable Long buildingId,
 	  @PathVariable Long roomId
 	) {
-		return ResponseEntity.ok(roomService.selectOne(roomId));
+		return ResponseEntity.ok(roomService.selectOne(buildingId, roomId));
+	}
+
+	@PostMapping("/{roomId}/setting-on")
+	public ResponseEntity<RoomDTO.Info> turnOn(
+	  /* TODO Member 추가 */
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId
+	) {
+		return ResponseEntity.ok(roomService.updateSwitch(buildingId, roomId, true));
+	}
+
+	@PostMapping("/{roomId}/setting-off")
+	public ResponseEntity<RoomDTO.Info> turnOff(
+	  /* TODO Member 추가 */
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId
+	) {
+		return ResponseEntity.ok(roomService.updateSwitch(buildingId, roomId, false));
+	}
+
+	@PatchMapping("/{roomId}/modify-encourage-message")
+	public ResponseEntity<RoomDTO.Info> modify(
+	  /* TODO Member 추가 */
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId,
+	  @RequestBody String encourageMessage
+	) {
+		return ResponseEntity.ok(roomService.updateEncourageMessage(buildingId, roomId, encourageMessage));
 	}
 
 }

--- a/src/main/java/com/core/back9/dto/RoomDTO.java
+++ b/src/main/java/com/core/back9/dto/RoomDTO.java
@@ -48,6 +48,7 @@ public class RoomDTO {
 		private Usage usage;
 		private Status status;
 		private float rating;
+		private SettingDTO.Info setting;
 		private LocalDateTime createdAt;
 		private LocalDateTime updatedAt;
 	}

--- a/src/main/java/com/core/back9/dto/SettingDTO.java
+++ b/src/main/java/com/core/back9/dto/SettingDTO.java
@@ -13,29 +13,10 @@ public class SettingDTO {
 	@NoArgsConstructor
 	@Builder
 	@Getter
-	public static class RegisterRequest {
-		private boolean ratingToggle;
-		private String message;
-	}
-
-	@AllArgsConstructor
-	@NoArgsConstructor
-	@Builder
-	@Getter
-	public static class RegisterResponse {
-		private Long id;
-		private LocalDateTime createdAt;
-	}
-
-	@AllArgsConstructor
-	@NoArgsConstructor
-	@Builder
-	@Getter
 	public static class Info {
 		private Long id;
 		private boolean ratingToggle;
-		private String message;
-		private LocalDateTime createdAt;
+		private String encourageMessage;
 		private LocalDateTime updatedAt;
 	}
 

--- a/src/main/java/com/core/back9/entity/Room.java
+++ b/src/main/java/com/core/back9/entity/Room.java
@@ -47,8 +47,14 @@ public class Room extends BaseEntity {
 	@OneToOne
 	private Contract contract;
 
+	@OneToOne(
+	  cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+	  orphanRemoval = true
+	)
+	private Setting setting;
+
 	@Builder
-	private Room(String name, String floor, float area, Usage usage, float rating, Building building, Member member) {
+	private Room(String name, String floor, float area, Usage usage, float rating, Building building, Member member, Setting setting) {
 		this.name = name;
 		this.floor = floor;
 		this.area = area;
@@ -57,6 +63,7 @@ public class Room extends BaseEntity {
 		this.building = building;
 		this.member = member;
 		this.status = Status.REGISTER;
+		this.setting = setting;
 	}
 
 	public void update(RoomDTO.Request request) {

--- a/src/main/java/com/core/back9/entity/Setting.java
+++ b/src/main/java/com/core/back9/entity/Setting.java
@@ -14,10 +14,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "settings")
 public class Setting extends BaseEntity {
 
-	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "room_id")
-	private Room room;
-
 	@Column(name = "rating_toggle")
 	private boolean ratingToggle;
 
@@ -29,10 +25,20 @@ public class Setting extends BaseEntity {
 	private Status status;
 
 	@Builder
-	public Setting(Room room, boolean ratingToggle, String encourageMessage, Status status) {
-		this.room = room;
-		this.ratingToggle = ratingToggle;
-		this.encourageMessage = encourageMessage;
-		this.status = status;
+	public Setting(String encourageMessage) {
+		this.ratingToggle = true;
+		this.encourageMessage = encourageMessage == null
+		  ? "안녕하세요\n\n평가를 통해\n오피스에서 함께하는 시간을\n더 즐겁고, 더 편리하게 만들어보아요!"
+		  : encourageMessage;
+		this.status = Status.REGISTER;
 	}
+
+	public void updateToggle(boolean value) {
+		this.ratingToggle = value;
+	}
+
+	public void updateEncourageMessage(String encourageMessage) {
+		this.encourageMessage = encourageMessage;
+	}
+
 }

--- a/src/main/java/com/core/back9/mapper/BuildingMapper.java
+++ b/src/main/java/com/core/back9/mapper/BuildingMapper.java
@@ -26,8 +26,6 @@ public interface BuildingMapper {
 
 	BuildingDTO.Response toResponse(Building building);
 
-	BuildingDTO.Info toInfo(Building building);
-
 	@Mapping(
 	  target = "roomPage",
 	  expression = "java(toRoomPage(building.getRoomList(), pageable))"

--- a/src/main/java/com/core/back9/mapper/RoomMapper.java
+++ b/src/main/java/com/core/back9/mapper/RoomMapper.java
@@ -3,6 +3,7 @@ package com.core.back9.mapper;
 import com.core.back9.dto.RoomDTO;
 import com.core.back9.entity.Building;
 import com.core.back9.entity.Room;
+import com.core.back9.entity.Setting;
 import org.mapstruct.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -18,7 +19,8 @@ import java.util.List;
 public interface RoomMapper {
 
 	@Mapping(target = "building", expression = "java(building)")
-	Room toEntity(@Context Building building, RoomDTO.Request request);
+	@Mapping(target = "setting", expression = "java(setting)")
+	Room toEntity(@Context Building building, RoomDTO.Request request, @Context Setting setting);
 
 	RoomDTO.Response toResponse(Room room);
 

--- a/src/main/java/com/core/back9/mapper/SettingMapper.java
+++ b/src/main/java/com/core/back9/mapper/SettingMapper.java
@@ -13,10 +13,6 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface SettingMapper {
 
-	Setting toEntity(SettingDTO.RegisterRequest registerRequest);
-
-	SettingDTO.RegisterResponse toRegisterResponse(Setting setting);
-
 	SettingDTO.Info toInfo(Setting setting);
 
 }

--- a/src/main/java/com/core/back9/repository/RoomRepository.java
+++ b/src/main/java/com/core/back9/repository/RoomRepository.java
@@ -14,10 +14,10 @@ import java.util.Optional;
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
-	Optional<Room> findFirstByIdAndStatus(Long roomId, Status status);
+	Optional<Room> findFirstByBuildingIdAndIdAndStatus(Long buildingId, Long roomId, Status status);
 
-	default Room getValidRoomWithIdOrThrow(Long roomId, Status status) {
-		return findFirstByIdAndStatus(roomId, status)
+	default Room getValidRoomWithIdOrThrow(Long buildingId, Long roomId, Status status) {
+		return findFirstByBuildingIdAndIdAndStatus(buildingId, roomId, status)
 		  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_ROOM));
 	}
 

--- a/src/main/java/com/core/back9/repository/SettingRepository.java
+++ b/src/main/java/com/core/back9/repository/SettingRepository.java
@@ -1,0 +1,10 @@
+package com.core.back9.repository;
+
+import com.core.back9.entity.Setting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SettingRepository extends JpaRepository<Setting, Long> {
+
+}

--- a/src/main/java/com/core/back9/service/BuildingService.java
+++ b/src/main/java/com/core/back9/service/BuildingService.java
@@ -32,15 +32,15 @@ public class BuildingService {
 	}
 
 	@Transactional(readOnly = true)
-	public BuildingDTO.Info selectOne(Long buildingId) {
+	public BuildingDTO.Info selectOne(Long buildingId, Pageable pageable) {
 		Building validBuilding = buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
-		return buildingMapper.toInfo(validBuilding);
+		return buildingMapper.toInfo(validBuilding, pageable);
 	}
 
-	public BuildingDTO.Info update(Long buildingId, BuildingDTO.Request request) {
+	public BuildingDTO.Info update(Long buildingId, BuildingDTO.Request request, Pageable pageable) {
 		Building validBuilding = buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
 		validBuilding.update(request);
-		return buildingMapper.toInfo(validBuilding);
+		return buildingMapper.toInfo(validBuilding, pageable);
 	}
 
 	public boolean delete(Long buildingId) {

--- a/src/main/java/com/core/back9/service/RoomService.java
+++ b/src/main/java/com/core/back9/service/RoomService.java
@@ -3,10 +3,12 @@ package com.core.back9.service;
 import com.core.back9.dto.RoomDTO;
 import com.core.back9.entity.Building;
 import com.core.back9.entity.Room;
+import com.core.back9.entity.Setting;
 import com.core.back9.entity.constant.Status;
 import com.core.back9.mapper.RoomMapper;
 import com.core.back9.repository.BuildingRepository;
 import com.core.back9.repository.RoomRepository;
+import com.core.back9.repository.SettingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,24 +23,25 @@ public class RoomService {
 	private final BuildingRepository buildingRepository;
 	private final RoomRepository roomRepository;
 	private final RoomMapper roomMapper;
+	private final SettingRepository settingRepository;
 
 	public RoomDTO.Response create(Long buildingId, RoomDTO.Request request) {
 		Building validBuilding = buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
-		Room newRoom = roomMapper.toEntity(validBuilding, request);
+		Room newRoom = roomMapper.toEntity(validBuilding, request, createSetting());
 		Room savedRoom = roomRepository.save(newRoom);
 		validBuilding.addRoom(savedRoom);
 		return roomMapper.toResponse(savedRoom);
 	}
 
-	public RoomDTO.Info update(Long roomId, RoomDTO.Request request) {
-		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(roomId, Status.REGISTER);
+	public RoomDTO.Info update(Long buildingId, Long roomId, RoomDTO.Request request) {
+		Room validRoom = currentRoom(buildingId, roomId);
 		validRoom.update(request);
 		return roomMapper.toInfo(validRoom);
 	}
 
 	public boolean delete(Long buildingId, Long roomId) {
 		Building validBuilding = buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
-		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(roomId, Status.REGISTER);
+		Room validRoom = currentRoom(buildingId, roomId);
 		validBuilding.removeRoom(validRoom);
 		validRoom.delete();
 		return validRoom.getStatus() == Status.UNREGISTER;
@@ -51,9 +54,32 @@ public class RoomService {
 	}
 
 	@Transactional(readOnly = true)
-	public RoomDTO.Info selectOne(Long roomId) {
-		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(roomId, Status.REGISTER);
+	public RoomDTO.Info selectOne(Long buildingId, Long roomId) {
+		Room validRoom = currentRoom(buildingId, roomId);
 		return roomMapper.toInfo(validRoom);
+	}
+
+	public RoomDTO.Info updateSwitch(Long buildingId, Long roomId, boolean value) {
+		Room validRoom = currentRoom(buildingId, roomId);
+		Setting currentSetting = validRoom.getSetting();
+		currentSetting.updateToggle(value);
+		return roomMapper.toInfo(validRoom);
+	}
+
+	public RoomDTO.Info updateEncourageMessage(Long buildingId, Long roomId, String encourageMessage) {
+		Room validRoom = currentRoom(buildingId, roomId);
+		Setting currentSetting = validRoom.getSetting();
+		currentSetting.updateEncourageMessage(encourageMessage);
+		return roomMapper.toInfo(validRoom);
+	}
+
+	private Room currentRoom(Long buildingId, Long roomId) {
+		return roomRepository.getValidRoomWithIdOrThrow(buildingId, roomId, Status.REGISTER);
+	}
+
+	public Setting createSetting() {
+		Setting newSetting = Setting.builder().build();
+		return settingRepository.save(newSetting);
 	}
 
 	// 소유자 추가하기

--- a/src/main/resources/db/migration/V7__room-include-default-setting.sql
+++ b/src/main/resources/db/migration/V7__room-include-default-setting.sql
@@ -1,0 +1,14 @@
+ALTER TABLE rooms
+    ADD setting_id BIGINT NULL;
+
+ALTER TABLE rooms
+    ADD CONSTRAINT uc_rooms_setting UNIQUE (setting_id);
+
+ALTER TABLE rooms
+    ADD CONSTRAINT FK_ROOMS_ON_SETTING FOREIGN KEY (setting_id) REFERENCES settings (id);
+
+ALTER TABLE settings
+DROP FOREIGN KEY FK_SETTINGS_ON_ROOM;
+
+ALTER TABLE settings
+DROP COLUMN room_id;

--- a/src/test/java/com/core/back9/controller/BuildingControllerTest.java
+++ b/src/test/java/com/core/back9/controller/BuildingControllerTest.java
@@ -146,7 +146,7 @@ class BuildingControllerTest {
 	public void givenBuildingIdWhenSelectOneBuildingThenBuildingInfo() throws Exception {
 		long selectId = 1L;
 
-		given(buildingService.selectOne(anyLong())).willReturn(infoList.get(0));
+		given(buildingService.selectOne(anyLong(), any(Pageable.class))).willReturn(infoList.get(0));
 
 		mockMvc.perform(get("/api/buildings/" + selectId))
 		  .andDo(print())
@@ -157,7 +157,7 @@ class BuildingControllerTest {
 		  .andExpect(jsonPath("$.zip_code").value(infoList.get(0).getZipCode()))
 		  .andExpect(jsonPath("$.created_at").value("2024-03-05 13:30:00"))
 		  .andExpect(jsonPath("$.updated_at").value("2024-03-05 13:30:00"));
-		verify(buildingService).selectOne(anyLong());
+		verify(buildingService).selectOne(anyLong(), any(Pageable.class));
 	}
 
 	@DisplayName("빌딩 정보 수정 성공")
@@ -175,7 +175,7 @@ class BuildingControllerTest {
 		  .zipCode("updated zipCode")
 		  .build();
 
-		given(buildingService.update(anyLong(), any(BuildingDTO.Request.class))).willReturn(updatedInfo);
+		given(buildingService.update(anyLong(), any(BuildingDTO.Request.class), any(Pageable.class))).willReturn(updatedInfo);
 
 		mockMvc.perform(
 			patch("/api/buildings/" + updateId)
@@ -187,7 +187,7 @@ class BuildingControllerTest {
 		  .andExpect(jsonPath("$.name").value(updateRequest.getName()))
 		  .andExpect(jsonPath("$.address").value(updateRequest.getAddress()))
 		  .andExpect(jsonPath("$.zip_code").value(updateRequest.getZipCode()));
-		verify(buildingService).update(anyLong(), any(BuildingDTO.Request.class));
+		verify(buildingService).update(anyLong(), any(BuildingDTO.Request.class), any(Pageable.class));
 	}
 
 	@DisplayName("빌딩 삭제 성공")

--- a/src/test/java/com/core/back9/controller/RoomControllerTest.java
+++ b/src/test/java/com/core/back9/controller/RoomControllerTest.java
@@ -100,7 +100,7 @@ class RoomControllerTest {
 		  .name("updated name")
 		  .floor("updated floor")
 		  .build();
-		given(roomService.update(anyLong(), any(RoomDTO.Request.class))).willReturn(updatedInfo);
+		given(roomService.update(anyLong(), anyLong(), any(RoomDTO.Request.class))).willReturn(updatedInfo);
 
 		mockMvc.perform(
 			patch("/api/buildings/" + selectedBuildingId + "/rooms/" + updateRoomId)
@@ -111,7 +111,7 @@ class RoomControllerTest {
 		  .andExpect(status().isOk())
 		  .andExpect(jsonPath("$.name").value(updateRequest.getName()))
 		  .andExpect(jsonPath("$.floor").value(updateRequest.getFloor()));
-		verify(roomService).update(anyLong(), any(RoomDTO.Request.class));
+		verify(roomService).update(anyLong(), anyLong(), any(RoomDTO.Request.class));
 	}
 
 	@DisplayName("호실 삭제 성공")
@@ -168,14 +168,14 @@ class RoomControllerTest {
 		  .floor("selected room floor")
 		  .build();
 
-		given(roomService.selectOne(anyLong())).willReturn(selectedInfo);
+		given(roomService.selectOne(anyLong(), anyLong())).willReturn(selectedInfo);
 
 		mockMvc.perform(get("/api/buildings/" + selectedBuildingId + "/rooms/" + selectRoomId))
 		  .andDo(print())
 		  .andExpect(status().isOk())
 		  .andExpect(jsonPath("$.name").value(selectedInfo.getName()))
 		  .andExpect(jsonPath("$.floor").value(selectedInfo.getFloor()));
-		verify(roomService).selectOne(anyLong());
+		verify(roomService).selectOne(anyLong(), anyLong());
 	}
 
 }

--- a/src/test/java/com/core/back9/repository/RoomRepositoryTest.java
+++ b/src/test/java/com/core/back9/repository/RoomRepositoryTest.java
@@ -107,7 +107,7 @@ class RoomRepositoryTest {
 		Room savedRoom = roomRepository.save(room);
 		long savedRoomId = savedRoom.getId();
 
-		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(savedRoomId, Status.REGISTER);
+		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(building.getId(), savedRoomId, Status.REGISTER);
 
 		assertThat(savedRoom).isNotNull();
 		assertThat(savedRoomId).isEqualTo(savedRoomId);
@@ -130,7 +130,7 @@ class RoomRepositoryTest {
 		Room savedRoom = roomRepository.save(room);
 		long savedRoomId = savedRoom.getId();
 
-		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(savedRoomId, Status.REGISTER);
+		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(building.getId(), savedRoomId, Status.REGISTER);
 		validRoom.update(request);
 
 		assertThat(validRoom).isNotNull();
@@ -144,7 +144,7 @@ class RoomRepositoryTest {
 		Room savedRoom = roomRepository.save(room);
 		long savedRoomId = savedRoom.getId();
 
-		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(savedRoomId, Status.REGISTER);
+		Room validRoom = roomRepository.getValidRoomWithIdOrThrow(building.getId(), savedRoomId, Status.REGISTER);
 		validRoom.delete();
 
 		assertThat(validRoom.getStatus()).isEqualTo(Status.UNREGISTER);

--- a/src/test/java/com/core/back9/service/BuildingServiceTest.java
+++ b/src/test/java/com/core/back9/service/BuildingServiceTest.java
@@ -43,9 +43,11 @@ class BuildingServiceTest {
 	private Building building;
 	private BuildingDTO.Request request;
 	private BuildingDTO.Info info;
+	private Pageable pageable;
 
 	@BeforeEach
 	public void initSetting() {
+		pageable = PageRequest.of(0, 10);
 		buildingService = new BuildingService(buildingRepository, buildingMapper);
 		building = Building.builder()
 		  .name("building name")
@@ -116,13 +118,13 @@ class BuildingServiceTest {
 		long buildingId = 1L;
 		given(buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER))
 		  .willReturn(building);
-		given(buildingMapper.toInfo(building)).willReturn(info);
+		given(buildingMapper.toInfo(building, pageable)).willReturn(info);
 
-		BuildingDTO.Info result = buildingService.selectOne(buildingId);
+		BuildingDTO.Info result = buildingService.selectOne(buildingId, pageable);
 
 		assertThat(result).isEqualTo(info);
 		verify(buildingRepository).getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
-		verify(buildingMapper).toInfo(building);
+		verify(buildingMapper).toInfo(building, pageable);
 	}
 
 	@DisplayName("빌딩 정보 수정 성공")
@@ -140,15 +142,15 @@ class BuildingServiceTest {
 		  .address(updateRequest.getAddress())
 		  .build();
 		given(buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER)).willReturn(building);
-		given(buildingMapper.toInfo(building)).willReturn(updatedInfo);
+		given(buildingMapper.toInfo(building, pageable)).willReturn(updatedInfo);
 
-		BuildingDTO.Info result = buildingService.update(buildingId, updateRequest);
+		BuildingDTO.Info result = buildingService.update(buildingId, updateRequest, pageable);
 
 		assertThat(result).isEqualTo(updatedInfo);
 		assertThat(building.getName()).isEqualTo(updateRequest.getName());
 		assertThat(building.getAddress()).isEqualTo(updateRequest.getAddress());
 		verify(buildingRepository).getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
-		verify(buildingMapper).toInfo(building);
+		verify(buildingMapper).toInfo(building, pageable);
 	}
 
 	@DisplayName("빌딩 삭제 성공")


### PR DESCRIPTION
## 📝작업 내용
> 1. 호실에 설정 연결, 설정에 있던 호실 제거 DB ver.7
> 2. 호실 등록 할 때 설정 함께 생성 되도록 구현
> 3. 설정 기본값으로 생성되기 때문에 불필요한 요청/응답 DTO/Mapper 제거
> 4. 설정 레포지토리 생성
> 5. 호실별 평가 설정 on/off 기능 구현 (테스트 미구현)
> 6. 호실별 평가 독려 메시지 수정 기능 구현 (테스트 미구현)

## #️⃣연관된 이슈
> closed : #52 

## 💬리뷰 요구사항(선택)
> 1.  SettingController, SettingService 만들었다가 아무리 생각해도 엔드포인트도 엉키고 호실에 포함된 설정이기때문에 RoomController, RoomService에서 설정 기능까지 처리했습니다.
> 2.  RoomController + SettingService 구조로 하려고 했는데 의존성 주입이 난잡해지는 모양이 나와서 1번 방식으로 결정했습니다.
> 3. 예상보다 너무 복잡하고 난해함...
