### PR TITLE
Contract 상태 변경 기능 관련 도메인 단위 로직 추가

### DIFF
--- a/src/main/java/com/core/back9/controller/TenantController.java
+++ b/src/main/java/com/core/back9/controller/TenantController.java
@@ -31,24 +31,6 @@ public class TenantController { // TODO: Member 구현 정도에 따라 관계 �
 
     }
 
-    @GetMapping("")
-    public ResponseEntity<TenantDTO.InfoList> getAllTenant(Pageable pageable) {
-
-        TenantDTO.InfoList infoList = tenantService.getAllTenant(pageable);
-
-        return ResponseEntity.ok(infoList);
-
-    }
-
-    @GetMapping("/{tenantId}")
-    public ResponseEntity<TenantDTO.Info> getOneTenant(@PathVariable(name = "tenantId") Long tenantId) {
-
-        TenantDTO.Info info = tenantService.getOneTenant(tenantId);
-
-        return ResponseEntity.ok(info);
-
-    }
-
     @PatchMapping("/{tenantId}")
     public ResponseEntity<TenantDTO.Info> modifyTenant(
             @PathVariable(name = "tenantId") Long tenantId,

--- a/src/main/java/com/core/back9/controller/TenantPublicController.java
+++ b/src/main/java/com/core/back9/controller/TenantPublicController.java
@@ -1,0 +1,37 @@
+package com.core.back9.controller;
+
+import com.core.back9.dto.TenantDTO;
+import com.core.back9.service.TenantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/public-api/tenants")
+@RestController
+public class TenantPublicController {
+
+    private final TenantService tenantService;
+
+    @GetMapping("")
+    public ResponseEntity<TenantDTO.InfoList> getAllTenant(Pageable pageable) {
+
+        TenantDTO.InfoList infoList = tenantService.getAllTenant(pageable);
+
+        return ResponseEntity.ok(infoList);
+
+    }
+
+    @GetMapping("/{tenantId}")
+    public ResponseEntity<TenantDTO.Info> getOneTenant(@PathVariable(name = "tenantId") Long tenantId) {
+
+        TenantDTO.Info info = tenantService.getOneTenant(tenantId);
+
+        return ResponseEntity.ok(info);
+
+    }
+}

--- a/src/main/java/com/core/back9/dto/ContractDTO.java
+++ b/src/main/java/com/core/back9/dto/ContractDTO.java
@@ -31,9 +31,16 @@ public class ContractDTO {
 	public static class UpdateRequest {
 		private LocalDate startDate;
 		private LocalDate endDate;
-		private LocalDate checkOut;
 		private Long deposit;
 		private Long rentalPrice;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class StatusChangeRequest {
+		private LocalDate checkOut;
 	}
 
 	@AllArgsConstructor

--- a/src/main/java/com/core/back9/entity/Contract.java
+++ b/src/main/java/com/core/back9/entity/Contract.java
@@ -5,6 +5,8 @@ import com.core.back9.dto.ContractDTO;
 import com.core.back9.entity.constant.ContractStatus;
 import com.core.back9.entity.constant.ContractType;
 import com.core.back9.entity.constant.Status;
+import com.core.back9.exception.ApiErrorCode;
+import com.core.back9.exception.ApiException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,63 +21,153 @@ import java.time.LocalDate;
 @Table(name = "contracts")
 public class Contract extends BaseEntity {
 
-	@Column(name = "start_date", nullable = false)
-	private LocalDate startDate; // 계약 시작일자
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate; // 계약 시작일자
 
-	@Column(name = "end_date", nullable = false)
-	private LocalDate endDate; // 계약 종료일자
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate; // 계약 종료일자
 
-	@Column(name = "check_out", nullable = false)
-	private LocalDate checkOut; // 실제 퇴실일자
+    @Column(name = "check_out", nullable = false)
+    private LocalDate checkOut; // 실제 퇴실일자
 
-	@Column(name = "deposit", nullable = false)
-	private Long deposit; // 보증금
+    @Column(name = "deposit", nullable = false)
+    private Long deposit; // 보증금
 
-	@Column(name = "rental_price", nullable = false)
-	private Long rentalPrice; // 월 납입금
+    @Column(name = "rental_price", nullable = false)
+    private Long rentalPrice; // 월 납입금
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "contract_status", nullable = false)
-	private ContractStatus contractStatus; // 계약의 상태
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contract_status", nullable = false)
+    private ContractStatus contractStatus; // 계약의 상태
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "contract_type")
-	private ContractType contractType;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contract_type")
+    private ContractType contractType;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "room_id")
-	private Room room;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "tenant_id")
-	private Tenant tenant;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id")
+    private Tenant tenant;
 
-	@Enumerated(EnumType.STRING)
-	@Column
-	private Status status;
+    @Enumerated(EnumType.STRING)
+    @Column
+    private Status status;
 
-	@Builder
-	private Contract(LocalDate startDate, LocalDate endDate, Long deposit, Long rentalPrice, Room room, Tenant tenant, ContractType contractType) {
-		this.startDate = startDate;
-		this.endDate = endDate;
-		this.checkOut = endDate; // 초기 생성시 checkOut == endDate
-		this.deposit = deposit;
-		this.rentalPrice = rentalPrice;
-		this.contractStatus = ContractStatus.PENDING; // 초기 생성시 ContractStatus == PENDING
-		this.contractType = contractType; // 초기 생성시 ContractStatus == INITIAL
-		this.room = room;
-		this.tenant = tenant;
-		this.status = Status.REGISTER;
-	}
+    @Builder
+    private Contract(LocalDate startDate, LocalDate endDate, Long deposit, Long rentalPrice, Room room, Tenant tenant, ContractType contractType) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.checkOut = endDate; // 초기 생성시 checkOut == endDate
+        this.deposit = deposit;
+        this.rentalPrice = rentalPrice;
+        this.contractStatus = ContractStatus.PENDING; // 초기 생성시 ContractStatus == PENDING
+        this.contractType = contractType;
+        this.room = room;
+        this.tenant = tenant;
+        this.status = Status.REGISTER;
 
-	public Contract infoUpdate(ContractDTO.UpdateRequest request) {
-		this.startDate = request.getStartDate();
-		this.endDate = request.getEndDate();
-		this.checkOut = request.getCheckOut();
-		this.deposit = request.getDeposit();
-		this.rentalPrice = request.getRentalPrice();
-		this.status = Status.REGISTER; // status = reqister 일 때만 변경 가능
-		return this;
-	}
+    }
 
+    public Contract infoUpdate(ContractDTO.UpdateRequest request) {
+        this.startDate = request.getStartDate();
+        this.endDate = request.getEndDate();
+        this.checkOut = request.getEndDate(); // 계약 내용의 변경을 가정해 checkOut는 endDate를 그대로 따라감
+        this.deposit = request.getDeposit();
+        this.rentalPrice = request.getRentalPrice();
+        this.status = Status.REGISTER; // status = reqister 일 때만 변경 가능
+
+        return this;
+
+    }
+
+    // 계약 완료 상태 지정
+    public ContractStatus contractCompleted(LocalDate startDate) { // 계약 대기 -> 완료 상태로 변경
+
+        if (this.contractStatus != ContractStatus.PENDING) {
+            throw new ApiException(ApiErrorCode.INVALID_CHANGE, "계약 대기 상태가 아닙니다.");
+        }
+
+        if (startDate.isAfter(this.startDate)) {
+            throw new ApiException(ApiErrorCode.INVALID_CHANGE, "계약에 명시된 시작 일자가 이미 지났습니다.");
+        }
+
+        return this.contractStatus = ContractStatus.COMPLETED;
+
+    }
+
+    // 계약 취소 상태 지정
+    public ContractStatus contractCanceledMissedStartDate() {
+
+        if (!(this.contractStatus == ContractStatus.PENDING ||
+              this.contractStatus == ContractStatus.COMPLETED)) { // 대기 & 완료 상태가 아닌 경우
+            throw new ApiException(ApiErrorCode.INVALID_CHANGE, "계약을 취소할 수 있는 상태가 아닙니다.");
+        }
+
+        return this.contractStatus = ContractStatus.CANCELED;
+
+    }
+
+    // 계약 이행 상태 지정
+    public ContractStatus contractInProgress(LocalDate startDate) { // 계약 완료 상태이면서 계약 시작 일자가 현재일과 같아야함
+
+        if (this.contractStatus != ContractStatus.COMPLETED) {
+            throw new ApiException(ApiErrorCode.INVALID_CHANGE, "계약 완료 상태가 아닙니다.");
+        }
+
+        if (!startDate.isEqual(this.startDate)) {
+            throw new ApiException(ApiErrorCode.INVALID_CHANGE, "계약 이행 일자가 아닙니다.");
+        }
+
+        return this.contractStatus = ContractStatus.IN_PROGRESS;
+
+    }
+
+    // 계약 만료 상태 지정
+    public Contract contractExpire(LocalDate endDate) {
+
+        if(this.contractStatus != ContractStatus.IN_PROGRESS) {
+            throw new ApiException(ApiErrorCode.INVALID_CHANGE, "계약 이행 상태가 아닙니다.");
+        }
+
+        if (endDate.isBefore(this.endDate)) { // 원하는 일자가 실제 만료일의 이전 일자인 경우
+            throw new ApiException(ApiErrorCode.INVALID_CHANGE,
+                    """
+                            만료 상태로 변경을 원하는 일자가
+                            정해진 만료 일자보다 이전 일자인 경우
+                            계약 만료 상태로 변경할 수 없습니다.
+                            """);
+        }
+
+        this.contractStatus = ContractStatus.EXPIRED;
+
+        return this;
+
+    }
+
+    // 계약 파기 상태 지정 (실제 퇴실 일자 변경과 함께 계약 파기 상태로 변경)
+    public Contract contractTerminate(ContractDTO.StatusChangeRequest request) {
+
+        if (request.getCheckOut().isAfter(this.endDate) ||
+            request.getCheckOut().isEqual(this.checkOut)) {
+            throw new ApiException(ApiErrorCode.INVALID_CHANGE,
+                    """
+                            원하는 퇴실 일자가 기존 퇴실 일자와 같거나
+                            계약 종료 일자 보다 이후의 일자라면
+                            계약 파기 상태로 변경할 수 없습니다.
+                            """);
+        }
+
+        if (this.contractStatus != ContractStatus.IN_PROGRESS) {
+            throw new ApiException(ApiErrorCode.CONTRACT_NOT_IN_PROGRESS);
+        }
+
+        this.checkOut = request.getCheckOut();
+        this.contractStatus = ContractStatus.TERMINATED;
+
+        return this;
+
+    }
 }

--- a/src/main/java/com/core/back9/entity/constant/ContractStatus.java
+++ b/src/main/java/com/core/back9/entity/constant/ContractStatus.java
@@ -14,7 +14,7 @@ public enum ContractStatus {
     // 이행, 만료의 경우 배치 처리로 전환 가능
     PENDING("계약 대기"),
     COMPLETED("계약 완료"),
-    CANCELED("계약 취소"),
+    CANCELED("계약 취소"), // 계약 등록(대기) 상태 이후 실제 계약 시작 일자까지 완료처리 하지 않으면 취소처리됨 or 이행 전 취소를 원할 시 취소처리
     IN_PROGRESS("계약 이행"),
     TERMINATED("계약 파기"),
     EXPIRED("계약 만료");

--- a/src/main/java/com/core/back9/exception/ApiErrorCode.java
+++ b/src/main/java/com/core/back9/exception/ApiErrorCode.java
@@ -20,13 +20,14 @@ public enum ApiErrorCode {
 	INCORRECT_EMAIL_FORMAT(HttpStatus.BAD_REQUEST.value(), "잘못된 이메일 형식입니다."),
 	INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "잘못된 비밀번호입니다."),
 	NOT_AUTHENTICATED_USER(HttpStatus.BAD_REQUEST.value(), "인증된 사용자가 아닙니다."),
+	INVALID_CHANGE(HttpStatus.BAD_REQUEST.value(), "잘못된 변경 내용입니다."),
+	CONTRACT_NOT_IN_PROGRESS(HttpStatus.BAD_REQUEST.value(), "계약이 이행 중인 상태가 아닙니다."),
 
 	THREAD_POOL_REJECTED(HttpStatus.REQUEST_TIMEOUT.value(), "더 이상 요청을 처리 할 수 없습니다"),
 
 	DO_NOT_HAVE_PERMISSION(HttpStatus.UNAUTHORIZED.value(), "권한이 없습니다"),
 
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SERVER ERROR"),
-	;
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SERVER ERROR");
 
 	private final Integer errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/core/back9/mapper/ContractMapper.java
+++ b/src/main/java/com/core/back9/mapper/ContractMapper.java
@@ -24,6 +24,8 @@ public interface ContractMapper {
 
     Contract toEntity(ContractDTO.UpdateRequest request);
 
+    Contract toEntity(ContractDTO.StatusChangeRequest request);
+
     ContractDTO.RegisterResponse toRegisterResponse(Contract contract);
 
     ContractDTO.Info toInfo(Contract contract);

--- a/src/test/java/com/core/back9/entity/ContractTest.java
+++ b/src/test/java/com/core/back9/entity/ContractTest.java
@@ -1,0 +1,405 @@
+package com.core.back9.entity;
+
+import com.core.back9.dto.ContractDTO;
+import com.core.back9.entity.constant.ContractStatus;
+import com.core.back9.entity.constant.ContractType;
+import com.core.back9.exception.ApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ContractTest {
+
+    @DisplayName("계약 완료 시나리오")
+    @TestFactory
+    Collection<DynamicTest> completeContractDynamicTest() {
+        // given
+        Contract contract = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        return List.of(
+                DynamicTest.dynamicTest("""
+                        계약에 명시된 시작 일자가 이미 지났다면
+                        계약을 완료 상태로 변경할 수 없다.
+                        """, () -> {
+                    // given
+                    LocalDate today = LocalDate.now().plusDays(11);
+
+                    // when & then
+                    assertThatThrownBy(() -> contract.contractCompleted(today))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("계약에 명시된 시작 일자가 이미 지났습니다.");
+                }),
+
+                DynamicTest.dynamicTest("""
+                        대기 상태인 계약을 완료 상태로 변경할 수 있다.
+                        """, () -> {
+                    // given
+                    LocalDate today = LocalDate.now().plusDays(10);
+
+                    // when
+                    ContractStatus contractStatus = contract.contractCompleted(today);
+
+                    // then
+                    assertThat(contractStatus).isEqualTo(ContractStatus.COMPLETED);
+                }),
+
+                DynamicTest.dynamicTest("""
+                        계약이 대기 상태가 아니라면 완료 상태로 변경할 수 없다.
+                        """, () -> {
+                    // given
+                    LocalDate today = LocalDate.now().plusDays(10);
+
+                    // when & then
+                    assertThatThrownBy(() -> contract.contractCompleted(today))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("계약 대기 상태가 아닙니다.");
+                })
+        );
+
+    }
+
+    @DisplayName("계약 취소 시나리오")
+    @TestFactory
+    Collection<DynamicTest> cancelContractDynamicTest() {
+        // given
+        Contract contract1 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        Contract contract2 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        LocalDate today = LocalDate.now().plusDays(10);
+        contract2.contractCompleted(today);
+
+        return List.of(
+                DynamicTest.dynamicTest("""
+                        대기 상태인 계약을 취소 상태로 변경할 수 있다.
+                        """, () -> {
+
+                    // when
+                    ContractStatus contractStatus = contract1.contractCanceledMissedStartDate();
+
+                    // then
+                    assertThat(contractStatus).isEqualTo(ContractStatus.CANCELED);
+                }),
+
+                DynamicTest.dynamicTest("""
+                        완료 상태인 계약을 취소 상태로 변경할 수 있다.
+                        """, () -> {
+
+                    // when
+                    ContractStatus contractStatus = contract2.contractCanceledMissedStartDate();
+
+                    // then
+                    assertThat(contractStatus).isEqualTo(ContractStatus.CANCELED);
+                }),
+
+                DynamicTest.dynamicTest("""
+                        계약 대기 혹은 완료 상태가 아니라면
+                        계약을 취소 상태로 변경할 수 없다.
+                        """, () -> {
+
+                    // when & then
+                    assertThatThrownBy(contract1::contractCanceledMissedStartDate)
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("계약을 취소할 수 있는 상태가 아닙니다.");
+
+                })
+        );
+
+    }
+
+    @DisplayName("계약 이행 시나리오")
+    @TestFactory
+    Collection<DynamicTest> inProgressContractDynamicTest() {
+        // given
+        Contract contract1 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        Contract contract2 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        LocalDate today = LocalDate.now().plusDays(10);
+        contract2.contractCompleted(today);
+
+        return List.of(
+                DynamicTest.dynamicTest("""
+                        완료 상태가 아닌 계약은 이행 상태로 변경할 수 없다.
+                        """, () -> {
+
+                    // when & then
+                    assertThatThrownBy(() -> contract1.contractInProgress(today))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("계약 완료 상태가 아닙니다.");
+                }),
+
+                DynamicTest.dynamicTest("""
+                        계약 이행 일자가 아니라면
+                        완료 상태인 계약을 이행 상태로 변경할 수 없다.
+                        """, () -> {
+
+                    // given
+                    LocalDate beforeStartDate = LocalDate.now().plusDays(9);
+
+                    // when & then
+                    assertThatThrownBy(() -> contract2.contractInProgress(beforeStartDate))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("계약 이행 일자가 아닙니다.");
+                }),
+
+                DynamicTest.dynamicTest("""
+                        완료 상태인 계약을 이행 상태로 변경할 수 있다.
+                        """, () -> {
+
+                    // when
+                    ContractStatus contractStatus = contract2.contractInProgress(today);
+
+                    // then
+                    assertThat(contractStatus).isEqualTo(ContractStatus.IN_PROGRESS);
+                })
+
+        );
+
+    }
+
+    @DisplayName("계약 만료 시나리오")
+    @TestFactory
+    Collection<DynamicTest> expireContractDynamicTest() {
+        // given
+        Contract contract1 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        Contract contract2 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        LocalDate today = LocalDate.now().plusDays(10);
+        contract2.contractCompleted(today); // 계약 이행 상태로 변경하기 위해 먼저 완료 상태로 변경
+        contract2.contractInProgress(today); // 계약 이행 상태로 변경
+
+        return List.of(
+                DynamicTest.dynamicTest("""
+                        이행 상태가 아닌 계약은 만료 상태로 변경할 수 없다.
+                        """, () -> {
+
+                    // given
+                    LocalDate endDate = LocalDate.now().plusDays(25);
+
+                    // when & then
+                    assertThatThrownBy(() -> contract1.contractExpire(endDate))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("계약 이행 상태가 아닙니다.");
+                }),
+
+                DynamicTest.dynamicTest("""
+                        만료를 원하는 일자가 정해진 만료일의 이전 일자인 경우
+                        계약 만료 상태로 변경할 수 없다.
+                        """, () -> {
+
+                    // given
+                    LocalDate endDate = LocalDate.now().plusDays(24);
+
+                    // when & then
+                    assertThatThrownBy(() -> contract2.contractExpire(endDate))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("""
+                                    만료 상태로 변경을 원하는 일자가
+                                    정해진 만료 일자보다 이전 일자인 경우
+                                    계약 만료 상태로 변경할 수 없습니다.
+                                    """);
+                }),
+
+                DynamicTest.dynamicTest("""
+                        이행 상태인 계약을 만료 상태로 변경할 수 있다.
+                        """, () -> {
+
+                    // given
+                    LocalDate endDate = LocalDate.now().plusDays(25);
+
+                    // when
+                    Contract contract = contract2.contractExpire(endDate);
+
+                    // then
+                    assertThat(contract)
+                            .extracting("endDate", "checkOut", "contractStatus")
+                            .contains(LocalDate.now().plusDays(25),
+                                    LocalDate.now().plusDays(25),
+                                    ContractStatus.EXPIRED);
+                })
+
+
+
+        );
+
+    }
+
+    @DisplayName("계약 파기 시나리오")
+    @TestFactory
+    Collection<DynamicTest> terminateContractDynamicTest() {
+        // given
+        Contract contract1 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        Contract contract2 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(25),
+                100000000L,
+                200000L,
+                ContractType.INITIAL
+        );
+
+        LocalDate today = LocalDate.now().plusDays(10);
+        contract2.contractCompleted(today); // 계약 이행 상태로 변경하기 위해 먼저 완료 상태로 변경
+        contract2.contractInProgress(today); // 계약 이행 상태로 변경
+
+        return List.of(
+                DynamicTest.dynamicTest("""
+                        퇴실하려는 일자가 계약 종료일자보다 이후 일자라면
+                        계약 파기가 성립하지 않는다.
+                        """, () -> {
+                    // given
+                    ContractDTO.StatusChangeRequest request = ContractDTO.StatusChangeRequest.builder()
+                            .checkOut(LocalDate.now().plusDays(26))
+                            .build();
+
+                    // when & then
+                    assertThatThrownBy(() -> contract1.contractTerminate(request))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("""
+                                    원하는 퇴실 일자가 기존 퇴실 일자와 같거나
+                                    계약 종료 일자 보다 이후의 일자라면
+                                    계약 파기 상태로 변경할 수 없습니다.
+                                    """);
+                }),
+
+                DynamicTest.dynamicTest("""
+                        퇴실하려는 일자가 기존 퇴실 일자와 같은 일자라면
+                        계약 파기가 성립하지 않는다.
+                        """, () -> {
+                    // given
+                    ContractDTO.StatusChangeRequest request = ContractDTO.StatusChangeRequest.builder()
+                            .checkOut(LocalDate.now().plusDays(25))
+                            .build();
+
+                    // when & then
+                    assertThatThrownBy(() -> contract1.contractTerminate(request))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("""
+                                    원하는 퇴실 일자가 기존 퇴실 일자와 같거나
+                                    계약 종료 일자 보다 이후의 일자라면
+                                    계약 파기 상태로 변경할 수 없습니다.
+                                            """);
+                }),
+
+                DynamicTest.dynamicTest("""
+                        파기하려는 계약의 상태가 이행 중이 아닌 경우
+                        계약 파기가 이루어지지 않는다.
+                        """, () -> {
+                    // given
+                    ContractDTO.StatusChangeRequest request = ContractDTO.StatusChangeRequest.builder()
+                            .checkOut(LocalDate.now().plusDays(23))
+                            .build();
+
+                    // when & then
+                    assertThatThrownBy(() -> contract1.contractTerminate(request))
+                            .isInstanceOf(ApiException.class)
+                            .extracting("errorMessage")
+                            .isEqualTo("계약이 이행 중인 상태가 아닙니다.");
+                }),
+
+                DynamicTest.dynamicTest("""
+                        이행 상태인 계약을 파기 상태로 변경할 수 있다.
+                        """, () -> {
+                    // given
+                    ContractDTO.StatusChangeRequest request = ContractDTO.StatusChangeRequest.builder()
+                            .checkOut(LocalDate.now().plusDays(23))
+                            .build();
+
+                    // when
+                    Contract contract = contract2.contractTerminate(request);
+
+                    // then
+                    assertThat(contract)
+                            .extracting("endDate", "checkOut", "contractStatus")
+                            .contains(LocalDate.now().plusDays(25),
+                                    LocalDate.now().plusDays(23),
+                                    ContractStatus.TERMINATED);
+
+                })
+        );
+
+    }
+
+    private Contract assumeContract(
+            LocalDate startDate,
+            LocalDate endDate,
+            Long deposit,
+            Long rentalPrice,
+            ContractType contractType) {
+
+        return Contract.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .deposit(deposit)
+                .rentalPrice(rentalPrice)
+                .contractType(contractType)
+                .build();
+
+    }
+}

--- a/src/test/java/com/core/back9/mapper/ContractMapperTest.java
+++ b/src/test/java/com/core/back9/mapper/ContractMapperTest.java
@@ -52,7 +52,6 @@ public class ContractMapperTest {
         ContractDTO.UpdateRequest request = ContractDTO.UpdateRequest.builder()
                 .startDate(LocalDate.now())
                 .endDate(LocalDate.now().plusDays(1))
-                .checkOut(LocalDate.now().plusDays(1))
                 .deposit(100000000L)
                 .rentalPrice(200000L)
                 .build();


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
Contract 상태 변경 기능을 담당하는 메서드 도메인 로직에 추가
기능 사용에 필요한 Mapper 및 DTO 추가
관련 단위 테스트 추가
기타 코드 수정 및 요구 사항 반영

## #️⃣연관된 이슈
> closed : #66

## 💬리뷰 요구사항(선택)

> Contract의 다양한 상태를 조건에 따라 변경하는 로직은 비즈니스 보다는 도메인 영역에서 담당하는게 옳다고 판단했고, 비즈니스 로직에 로직이 추가될 경우 비즈니스 로직의 규모가 너무 커질 것으로 생각해 도메인 로직에 해당 기능들을 추가했습니다.
batch 처리 이전에 필요한 기능이고, 기능을 구현하다 보니 코드 규모가 생각보다 커진 관계로 관련 테스트와 프로덕트 코드를 먼저 반영하기로 결정했습니다.
