### PR TITLE
호실-계약 연관관계 추가 구현

### DIFF
--- a/src/main/java/com/core/back9/dto/ContractDTO.java
+++ b/src/main/java/com/core/back9/dto/ContractDTO.java
@@ -77,6 +77,7 @@ public class ContractDTO {
 	@Getter
 	public static class Info {
 		private Long id;
+		private TenantDTO.SimpleInfo tenant;
 		private LocalDate startDate;
 		private LocalDate endDate;
 		private LocalDate checkOut;

--- a/src/main/java/com/core/back9/dto/RoomDTO.java
+++ b/src/main/java/com/core/back9/dto/RoomDTO.java
@@ -57,6 +57,7 @@ public class RoomDTO {
 		private Usage usage;
 		private Status status;
 		private float rating;
+		private ContractDTO.InfoList contracts;
 		private SettingDTO.Info setting;
 		private LocalDateTime createdAt;
 		private LocalDateTime updatedAt;

--- a/src/main/java/com/core/back9/dto/TenantDTO.java
+++ b/src/main/java/com/core/back9/dto/TenantDTO.java
@@ -53,4 +53,14 @@ public class TenantDTO {
 		private List<Info> infoList;
 	}
 
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class SimpleInfo {
+		private Long tenantId;
+		private String tenantName;
+		private String companyNumber;
+	}
+
 }

--- a/src/main/java/com/core/back9/entity/Room.java
+++ b/src/main/java/com/core/back9/entity/Room.java
@@ -85,4 +85,12 @@ public class Room extends BaseEntity {
 		this.member = member;
 	}
 
+	public void addContract(Contract contract) {
+		this.contracts.add(contract);
+	}
+
+	public List<Contract> getContractList() {
+		return this.contracts;
+	}
+
 }

--- a/src/main/java/com/core/back9/mapper/ContractMapper.java
+++ b/src/main/java/com/core/back9/mapper/ContractMapper.java
@@ -32,6 +32,8 @@ public interface ContractMapper {
 
     ContractDTO.RegisterResponse toRegisterResponse(Contract contract);
 
+    @Mapping(source = "contract.tenant.id", target = "tenant.tenantId")
+    @Mapping(source = "contract.tenant.name", target = "tenant.tenantName")
     ContractDTO.Info toInfo(Contract contract);
 
     ContractDTO.InfoList toInfoList(Long count, List<ContractDTO.Info> infoList);

--- a/src/main/java/com/core/back9/mapper/RoomMapper.java
+++ b/src/main/java/com/core/back9/mapper/RoomMapper.java
@@ -1,11 +1,9 @@
 package com.core.back9.mapper;
 
+import com.core.back9.dto.ContractDTO;
 import com.core.back9.dto.MemberDTO;
 import com.core.back9.dto.RoomDTO;
-import com.core.back9.entity.Building;
-import com.core.back9.entity.Member;
-import com.core.back9.entity.Room;
-import com.core.back9.entity.Setting;
+import com.core.back9.entity.*;
 import org.mapstruct.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -18,12 +16,15 @@ import java.util.List;
   componentModel = MappingConstants.ComponentModel.SPRING,
   unmappedSourcePolicy = ReportingPolicy.IGNORE,
   unmappedTargetPolicy = ReportingPolicy.IGNORE,
-  uses = MemberMapper.class
+  uses = {MemberMapper.class, ContractMapper.class}
 )
 public interface RoomMapper {
 
 	@Autowired
 	MemberMapper memberMapper = new MemberMapperImpl();
+
+	@Autowired
+	ContractMapper contractMapper = new ContractMapperImpl();
 
 	@Mapping(target = "building", expression = "java(building)")
 	@Mapping(target = "setting", expression = "java(setting)")
@@ -31,6 +32,8 @@ public interface RoomMapper {
 
 	RoomDTO.Response toResponse(Room room);
 
+
+	@Mapping(target = "contracts", expression = "java(toContractInfoList(room.getContractList()))")
 	RoomDTO.Info toInfo(Room room);
 
 	List<RoomDTO.Info> toInfoList(List<Room> rooms);
@@ -55,6 +58,12 @@ public interface RoomMapper {
 	@Named("toOwnerInfo")
 	default MemberDTO.OwnerInfo toOwnerInfo(Member member) {
 		return memberMapper.toOwnerInfo(member);
+	}
+
+	@Named("toContractInfoList")
+	default ContractDTO.InfoList toContractInfoList(List<Contract> contracts) {
+		List<ContractDTO.Info> list = contracts.stream().map(contractMapper::toInfo).toList();
+		return ContractDTO.InfoList.builder().count((long) list.size()).infoList(list).build();
 	}
 
 }

--- a/src/main/java/com/core/back9/mapper/TenantMapper.java
+++ b/src/main/java/com/core/back9/mapper/TenantMapper.java
@@ -21,4 +21,8 @@ public interface TenantMapper {
 
 	TenantDTO.InfoList toInfoList(Long count, List<TenantDTO.Info> infoList);
 
+	@Mapping(source = "id", target = "tenantId")
+	@Mapping(source = "name", target = "tenantName")
+	TenantDTO.SimpleInfo toSimpleInfo(Tenant tenant);
+
 }

--- a/src/main/java/com/core/back9/service/ContractService.java
+++ b/src/main/java/com/core/back9/service/ContractService.java
@@ -63,6 +63,8 @@ public class ContractService {
 
         Contract completedContract = savedContract.contractComplete(); // 계약 무조건 완료처리 (계약 등록과 동시에 실행되는 완료처리라 기간 검증 필요X)
 
+        room.addContract(completedContract);
+
         return contractMapper.toRegisterResponse(completedContract);
 
     }
@@ -88,6 +90,8 @@ public class ContractService {
         Contract savedContract = contractRepository.save(validContract);
 
         Contract completedContract = savedContract.contractComplete();
+
+        room.addContract(completedContract);
 
         return contractMapper.toInfo(completedContract);
 


### PR DESCRIPTION
## 📝작업 내용
> 신규계약, 재계약 생성 시 호실에 계약사항 추가
> 계약 조회 데이터에 입주사 정보 추가
> 빌딩, 호실 조회 시 계약정보(입주사 포함) 데이터 API 테스트 완료

## #️⃣연관된 이슈
> closed : #79

## 💬리뷰 요구사항(선택)
> 뿅
