### PR TITLE
중복 계약 조회 쿼리 개선

### DIFF
--- a/src/main/java/com/core/back9/controller/ContractController.java
+++ b/src/main/java/com/core/back9/controller/ContractController.java
@@ -101,7 +101,7 @@ public class ContractController { // TODO: Tenant, Member 구현 정도에 따�
     }
 
     @PatchMapping("/{contractId}/complete")
-    public ResponseEntity<ContractDTO.statusInfo> completeContract(
+    public ResponseEntity<ContractDTO.StatusInfo> completeContract(
             @AuthMember MemberDTO.Info member,
             @PathVariable(name = "buildingId") Long buildingId,
             @PathVariable(name = "roomId") Long roomId,
@@ -110,14 +110,14 @@ public class ContractController { // TODO: Tenant, Member 구현 정도에 따�
 
         LocalDate startDate = LocalDate.now();
 
-        ContractDTO.statusInfo statusInfo = contractService.completeContract(member, buildingId, roomId, contractId, startDate);
+        ContractDTO.StatusInfo statusInfo = contractService.completeContract(member, buildingId, roomId, contractId, startDate);
 
         return ResponseEntity.ok(statusInfo);
 
     }
 
     @PatchMapping("/{contractId}/cancel")
-    public ResponseEntity<ContractDTO.statusInfo> cancelContract(
+    public ResponseEntity<ContractDTO.StatusInfo> cancelContract(
             @AuthMember MemberDTO.Info member,
             @PathVariable(name = "buildingId") Long buildingId,
             @PathVariable(name = "roomId") Long roomId,
@@ -126,14 +126,14 @@ public class ContractController { // TODO: Tenant, Member 구현 정도에 따�
 
         LocalDate startDate = LocalDate.now();
 
-        ContractDTO.statusInfo statusInfo = contractService.cancelContract(member, buildingId, roomId, contractId, startDate);
+        ContractDTO.StatusInfo statusInfo = contractService.cancelContract(member, buildingId, roomId, contractId, startDate);
 
         return ResponseEntity.ok(statusInfo);
 
     }
 
     @PatchMapping("/{contractId}/progress")
-    public ResponseEntity<ContractDTO.statusInfo> progressContract(
+    public ResponseEntity<ContractDTO.StatusInfo> progressContract(
             @AuthMember MemberDTO.Info member,
             @PathVariable(name = "buildingId") Long buildingId,
             @PathVariable(name = "roomId") Long roomId,
@@ -142,14 +142,14 @@ public class ContractController { // TODO: Tenant, Member 구현 정도에 따�
 
         LocalDate startDate = LocalDate.now();
 
-        ContractDTO.statusInfo statusInfo = contractService.progressContract(member, buildingId, roomId, contractId, startDate);
+        ContractDTO.StatusInfo statusInfo = contractService.progressContract(member, buildingId, roomId, contractId, startDate);
 
         return ResponseEntity.ok(statusInfo);
 
     }
 
     @PatchMapping("/{contractId}/expire")
-    public ResponseEntity<ContractDTO.statusInfo> expireContract(
+    public ResponseEntity<ContractDTO.StatusInfo> expireContract(
             @AuthMember MemberDTO.Info member,
             @PathVariable(name = "buildingId") Long buildingId,
             @PathVariable(name = "roomId") Long roomId,
@@ -158,14 +158,14 @@ public class ContractController { // TODO: Tenant, Member 구현 정도에 따�
 
         LocalDate endDate = LocalDate.now();
 
-        ContractDTO.statusInfo statusInfo = contractService.expireContract(member, buildingId, roomId, contractId, endDate);
+        ContractDTO.StatusInfo statusInfo = contractService.expireContract(member, buildingId, roomId, contractId, endDate);
 
         return ResponseEntity.ok(statusInfo);
 
     }
 
     @PatchMapping("/{contractId}/terminate")
-    public ResponseEntity<ContractDTO.statusInfo> terminateContract(
+    public ResponseEntity<ContractDTO.StatusInfo> terminateContract(
             @AuthMember MemberDTO.Info member,
             @PathVariable(name = "buildingId") Long buildingId,
             @PathVariable(name = "roomId") Long roomId,
@@ -173,7 +173,7 @@ public class ContractController { // TODO: Tenant, Member 구현 정도에 따�
             @RequestParam(name = "checkOut") LocalDate checkOut // 더 적합한 방법으로 일자를 받을 방법 고민 중
     ) {
 
-        ContractDTO.statusInfo statusInfo = contractService.terminateContract(member, buildingId, roomId, contractId, checkOut);
+        ContractDTO.StatusInfo statusInfo = contractService.terminateContract(member, buildingId, roomId, contractId, checkOut);
 
         return ResponseEntity.ok(statusInfo);
 

--- a/src/main/java/com/core/back9/dto/ContractDTO.java
+++ b/src/main/java/com/core/back9/dto/ContractDTO.java
@@ -1,7 +1,6 @@
 package com.core.back9.dto;
 
 import com.core.back9.entity.constant.ContractStatus;
-import com.core.back9.entity.constant.Status;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -92,7 +91,7 @@ public class ContractDTO {
 	@NoArgsConstructor
 	@Builder
 	@Getter
-	public static class statusInfo {
+	public static class StatusInfo {
 		private Long id;
 		private LocalDate startDate;
 		private LocalDate endDate;

--- a/src/main/java/com/core/back9/mapper/ContractMapper.java
+++ b/src/main/java/com/core/back9/mapper/ContractMapper.java
@@ -38,6 +38,6 @@ public interface ContractMapper {
 
     ContractDTO.InfoList toInfoList(Long count, List<ContractDTO.Info> infoList);
 
-    ContractDTO.statusInfo toStatusInfo(Contract contract);
+    ContractDTO.StatusInfo toStatusInfo(Contract contract);
 
 }

--- a/src/main/java/com/core/back9/repository/ContractRepository.java
+++ b/src/main/java/com/core/back9/repository/ContractRepository.java
@@ -2,7 +2,6 @@ package com.core.back9.repository;
 
 import com.core.back9.entity.Contract;
 import com.core.back9.entity.constant.ContractStatus;
-import com.core.back9.entity.constant.ContractType;
 import com.core.back9.entity.constant.Status;
 import com.core.back9.exception.ApiErrorCode;
 import com.core.back9.exception.ApiException;
@@ -52,14 +51,15 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
             """)
     Optional<Integer> deleteRegisteredContract(Status status, Long roomId, Long contractId);
 
+    // TODO : 기간 검증 로직에 대해 추가적인 고민 해보기
     @Query("""
             select c
             from Contract c
             where c.room.id=?1
             and c.contractStatus IN (?2)
-            and c.endDate>?3
+            and((c.endDate>?3 and c.startDate<?3) or (c.startDate <?4 and c.endDate>?4))
             """)
-    Optional<List<Contract>> findByContract(Long roomId, List<ContractStatus> statusList, LocalDate startDate);
+    Optional<List<Contract>> findByContractDuplicate(Long roomId, List<ContractStatus> statusList, LocalDate startDate, LocalDate endDate);
 
     @Query("""
             select c

--- a/src/main/java/com/core/back9/service/ContractService.java
+++ b/src/main/java/com/core/back9/service/ContractService.java
@@ -51,7 +51,7 @@ public class ContractService {
         // 공실 유무 체크(내가 계약 이행을 원하는 일자에 이미 맺어진 계약이 있는지 체크)
         List<ContractStatus> statusList = List.of(ContractStatus.PENDING, ContractStatus.COMPLETED, ContractStatus.IN_PROGRESS);
 
-        contractRepository.findByContract(roomId, statusList, request.getStartDate())
+        contractRepository.findByContractDuplicate(roomId, statusList, request.getStartDate(), request.getEndDate())
                 .ifPresent(contracts -> {
                     if (!contracts.isEmpty()) {
                         throw new ApiException(ApiErrorCode.ROOM_ALREADY_ASSIGNED);
@@ -167,7 +167,7 @@ public class ContractService {
 
     }
 
-    public ContractDTO.statusInfo completeContract(
+    public ContractDTO.StatusInfo completeContract(
             MemberDTO.Info member,
             Long buildingId,
             Long roomId,
@@ -187,7 +187,7 @@ public class ContractService {
 
     }
 
-    public ContractDTO.statusInfo cancelContract(
+    public ContractDTO.StatusInfo cancelContract(
             MemberDTO.Info member,
             Long buildingId,
             Long roomId,
@@ -207,7 +207,7 @@ public class ContractService {
 
     }
 
-    public ContractDTO.statusInfo progressContract(
+    public ContractDTO.StatusInfo progressContract(
             MemberDTO.Info member,
             Long buildingId,
             Long roomId,
@@ -226,7 +226,7 @@ public class ContractService {
         return contractMapper.toStatusInfo(contractProgressed);
     }
 
-    public ContractDTO.statusInfo expireContract(
+    public ContractDTO.StatusInfo expireContract(
             MemberDTO.Info member,
             Long buildingId,
             Long roomId,
@@ -251,7 +251,7 @@ public class ContractService {
 
     }
 
-    public ContractDTO.statusInfo terminateContract(
+    public ContractDTO.StatusInfo terminateContract(
             MemberDTO.Info member,
             Long buildingId,
             Long roomId,

--- a/src/test/java/com/core/back9/mapper/ContractMapperTest.java
+++ b/src/test/java/com/core/back9/mapper/ContractMapperTest.java
@@ -258,6 +258,32 @@ public class ContractMapperTest {
 
     }
 
+    @Test
+    @DisplayName("Contract 엔티티를 StatusInfo로 매핑할 수 있다.")
+    void contractToStatusInfo() {
+        // given
+        Contract contract = assumeContract(
+                LocalDate.now(),
+                LocalDate.now().plusDays(1),
+                100000000L,
+                200000L
+        );
+
+        // when
+        ContractDTO.StatusInfo statusInfo = contractMapper.toStatusInfo(contract);
+
+        // then
+        assertThat(statusInfo)
+                .extracting("startDate", "endDate", "checkOut", "contractStatus")
+                .contains(
+                        LocalDate.now(),
+                        LocalDate.now().plusDays(1),
+                        LocalDate.now().plusDays(1),
+                        ContractStatus.PENDING
+                );
+
+    }
+
     private Contract assumeContract(
             LocalDate startDate,
             LocalDate endDate,

--- a/src/test/java/com/core/back9/repository/ContractRepositoryTest.java
+++ b/src/test/java/com/core/back9/repository/ContractRepositoryTest.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -264,6 +265,229 @@ class ContractRepositoryTest extends ContractRepositoryFixture {
                         ContractStatus.PENDING,
                         ContractType.INITIAL
                 );
+
+    }
+
+    @Test
+    @DisplayName("선택한 호실에 계약 시작을 원하는 날짜와 겹치는 일자의 계약이 존재하는지 조회할 수 있다.")
+    void findByContractDuplicateCase1() {
+        // given
+        List<ContractStatus> statusList = List.of(ContractStatus.PENDING, ContractStatus.COMPLETED, ContractStatus.IN_PROGRESS);
+        Contract contract = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+
+        Contract savedContract = contractRepository.save(contract);
+        savedContract.contractComplete();
+
+        LocalDate contractStartDate = LocalDate.now().plusDays(19);
+        LocalDate contractEndDate = LocalDate.now().plusDays(39);
+
+        // when
+        Optional<List<Contract>> contractList = contractRepository.findByContractDuplicate(room1.getId(), statusList, contractStartDate, contractEndDate);
+
+        // then
+        assertThat(contractList.get()).hasSize(1);
+        assertThat(contractList.get())
+                .extracting("startDate", "endDate", "contractStatus")
+                .contains(
+                        tuple(
+                                LocalDate.now().plusDays(10),
+                                LocalDate.now().plusDays(20),
+                                ContractStatus.COMPLETED
+                        ));
+
+    }
+
+    @Test
+    @DisplayName("선택한 호실에 계약 종료를 원하는 날짜와 겹치는 일자의 계약이 존재하는지 조회할 수 있다.")
+    void findByContractDuplicateCase2() {
+        // given
+        List<ContractStatus> statusList = List.of(ContractStatus.PENDING, ContractStatus.COMPLETED, ContractStatus.IN_PROGRESS);
+        Contract contract = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+
+        Contract savedContract = contractRepository.save(contract);
+        savedContract.contractComplete();
+
+        LocalDate contractStartDate = LocalDate.now().plusDays(19);
+        LocalDate contractEndDate = LocalDate.now().plusDays(39);
+
+        // when
+        Optional<List<Contract>> contractList = contractRepository.findByContractDuplicate(room1.getId(), statusList, contractStartDate, contractEndDate);
+
+        // then
+        assertThat(contractList.get()).hasSize(1);
+        assertThat(contractList.get())
+                .extracting("startDate", "endDate", "contractStatus")
+                .contains(
+                        tuple(
+                                LocalDate.now().plusDays(10),
+                                LocalDate.now().plusDays(20),
+                                ContractStatus.COMPLETED
+                        ));
+
+    }
+
+    @Test
+    @DisplayName("선택한 호실에 계약 시작을 원하는 날짜와 겹치는 일자의 계약이 2개 이상 존재하는지 조회할 수 있다.(필터링 조건 동시충족)")
+    void findByContractDuplicateCase3() {
+        // given
+        List<ContractStatus> statusList = List.of(ContractStatus.PENDING, ContractStatus.COMPLETED, ContractStatus.IN_PROGRESS);
+        Contract contract1 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+        Contract savedContract1 = contractRepository.save(contract1);
+Contract contract2 = assumeContract(
+                LocalDate.now().plusDays(30),
+                LocalDate.now().plusDays(40),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+        Contract savedContract2 = contractRepository.save(contract2);
+
+
+        savedContract1.contractComplete();
+        savedContract2.contractComplete();
+
+        LocalDate contractStartDate = LocalDate.now().plusDays(19);
+        LocalDate contractEndDate = LocalDate.now().plusDays(39);
+
+        // when
+        Optional<List<Contract>> contractList = contractRepository.findByContractDuplicate(room1.getId(), statusList, contractStartDate, contractEndDate);
+
+        // then
+        assertThat(contractList.get()).hasSize(2);
+        assertThat(contractList.get())
+                .extracting("startDate", "endDate", "contractStatus")
+                .contains(
+                        tuple(
+                                LocalDate.now().plusDays(10),
+                                LocalDate.now().plusDays(20),
+                                ContractStatus.COMPLETED
+                        ));
+
+    }
+
+    @Test
+    @DisplayName("선택한 호실에 계약을 원하는 날짜와 겹치는 일자의 계약이 존재하는지 조회할 수 있다.")
+    void findByContractDuplicateCase4() {
+        // given
+        List<ContractStatus> statusList = List.of(ContractStatus.PENDING, ContractStatus.COMPLETED, ContractStatus.IN_PROGRESS);
+        Contract contract = assumeContract(
+                LocalDate.now().plusDays(14),
+                LocalDate.now().plusDays(26),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+
+        Contract savedContract = contractRepository.save(contract);
+        savedContract.contractComplete();
+
+        LocalDate contractStartDate = LocalDate.now().plusDays(15);
+        LocalDate contractEndDate = LocalDate.now().plusDays(25);
+
+        // when
+        Optional<List<Contract>> contractList = contractRepository.findByContractDuplicate(room1.getId(), statusList, contractStartDate, contractEndDate);
+
+        // then
+        assertThat(contractList.get()).hasSize(1);
+        assertThat(contractList.get())
+                .extracting("startDate", "endDate", "contractStatus")
+                .contains(
+                        tuple(
+                                LocalDate.now().plusDays(14),
+                                LocalDate.now().plusDays(26),
+                                ContractStatus.COMPLETED
+                        ));
+
+    }
+
+    @Test
+    @DisplayName("선택한 호실에 계약 시작을 원하는 날짜와 겹치는 일자의 계약이 없다면 빈 리스트를 반환한다.")
+    void findByContractDuplicateEmpty() {
+        // given
+        List<ContractStatus> statusList = List.of(ContractStatus.PENDING, ContractStatus.COMPLETED, ContractStatus.IN_PROGRESS);
+        Contract contract = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(30),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract savedContract = contractRepository.save(contract);
+        savedContract.contractComplete();
+
+        LocalDate contractStartDate = LocalDate.now().plusDays(8);
+        LocalDate contractEndDate = LocalDate.now().plusDays(9);
+
+        // when
+        Optional<List<Contract>> contractList = contractRepository.findByContractDuplicate(room1.getId(), statusList, contractStartDate, contractEndDate);
+
+        // then
+        assertThat(contractList.get()).isEmpty();
+
+    }
+
+    @Test
+    @DisplayName("선택한 호실에 계약 시작을 원하는 날짜와 겹치는 일자의 계약이 존재해도 정상 상태가 아닐 시 조회되지 않는다.")
+    void findByContractDuplicateAbnormal() {
+        // given
+        List<ContractStatus> statusList = List.of(ContractStatus.PENDING, ContractStatus.COMPLETED, ContractStatus.IN_PROGRESS);
+        Contract contract = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract savedContract = contractRepository.save(contract);
+        savedContract.contractComplete();
+        savedContract.contractInProgress();
+        savedContract.contractExpire();
+
+        LocalDate contractStartDate = LocalDate.now().plusDays(19);
+        LocalDate contractEndDate = LocalDate.now().plusDays(39);
+
+        // when
+        Optional<List<Contract>> contractList = contractRepository.findByContractDuplicate(room1.getId(), statusList, contractStartDate, contractEndDate);
+
+        // then
+        assertThat(contractList.get()).isEmpty();
 
     }
 

--- a/src/test/java/com/core/back9/service/ContractServiceTest.java
+++ b/src/test/java/com/core/back9/service/ContractServiceTest.java
@@ -52,7 +52,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                 .build();
 
         // when
-        ContractDTO.statusInfo updatedContract = contractService.completeContract(memberInfo, 1L, 1L, savedContract.getId(), today);
+        ContractDTO.StatusInfo updatedContract = contractService.completeContract(memberInfo, 1L, 1L, savedContract.getId(), today);
 
         // then
         assertThat(updatedContract)
@@ -183,7 +183,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                 .build();
 
         // when
-        ContractDTO.statusInfo updatedContract = contractService.cancelContract(member, 1L, 1L, savedContract.getId(), today);
+        ContractDTO.StatusInfo updatedContract = contractService.cancelContract(member, 1L, 1L, savedContract.getId(), today);
 
         // then
         assertThat(updatedContract)
@@ -253,7 +253,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                 .build();
 
         // when
-        ContractDTO.statusInfo updatedContract = contractService.progressContract(member, 1L, 1L, savedContract.getId(), today);
+        ContractDTO.StatusInfo updatedContract = contractService.progressContract(member, 1L, 1L, savedContract.getId(), today);
 
         // then
         assertThat(updatedContract)
@@ -331,7 +331,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                 .build();
 
         // when
-        ContractDTO.statusInfo updatedContract = contractService.expireContract(member, 1L, 1L, savedContract.getId(), today);
+        ContractDTO.StatusInfo updatedContract = contractService.expireContract(member, 1L, 1L, savedContract.getId(), today);
 
         // then
         assertThat(updatedContract)
@@ -408,7 +408,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                 .build();
 
         // when
-        ContractDTO.statusInfo updatedContract = contractService.terminateContract(member, 1L, 1L, savedContract.getId(), today);
+        ContractDTO.StatusInfo updatedContract = contractService.terminateContract(member, 1L, 1L, savedContract.getId(), today);
 
         // then
         assertThat(updatedContract)


### PR DESCRIPTION
## 📝작업 내용
> 최초 계약시 계약 하려는 호실에 정상 상태인 기계약이 존재하는 경우 필터링하는 쿼리 개선
>필터링 시나리오
ex) A 호실과 계약을 원하는 일자 2024-06-01 ~ 2024-10-31
a. a호실에 2024-04-01 ~ 2024-06-30의 계약이 존재 (06-30 > 06-01 : 기간 겹치므로 필터링 대상)
b. a호실에 2024-09-01 ~ 2024-12-31의 계약이 존재 (10-31 < 12-31 : 기간이 겹치므로 필터링 대상)
c. a호실에 2024-06-15 ~ 2024-10-14의 계약이 존재 (기 계약이 원하는 계약 기간 중에 포함되므로 필터링 대상)

## #️⃣연관된 이슈
> closed : #83

## 💬리뷰 요구사항(선택)

> 쿼리 테스트는 마친 상태로 jpql에 적용하였습니다.
