### PR TITLE
평가 레코드 생성 구현

### DIFF
--- a/src/main/java/com/core/back9/controller/RoomController.java
+++ b/src/main/java/com/core/back9/controller/RoomController.java
@@ -2,8 +2,10 @@ package com.core.back9.controller;
 
 import com.core.back9.dto.MemberDTO;
 import com.core.back9.dto.RoomDTO;
+import com.core.back9.entity.constant.RatingType;
 import com.core.back9.security.AuthMember;
 import com.core.back9.service.RoomService;
+import com.core.back9.service.ScoreService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class RoomController {
 
 	private final RoomService roomService;
+	private final ScoreService scoreService;
 
 	@PostMapping("")
 	public ResponseEntity<RoomDTO.Response> register(
@@ -100,6 +103,17 @@ public class RoomController {
 	  @PathVariable Long ownerId
 	) {
 		return ResponseEntity.ok(roomService.settingOwner(member, buildingId, roomId, ownerId));
+	}
+
+	@PatchMapping("/{roomId}/scores-generate")
+	public void evaluation(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId,
+	  @RequestParam RatingType ratingType
+	) {
+		// 빌딩-호실에 대해 현재 계약중인 입주사에 평가를 수동으로 발생
+		scoreService.create(member, buildingId, roomId, ratingType);
 	}
 
 }

--- a/src/main/java/com/core/back9/dto/ScoreDTO.java
+++ b/src/main/java/com/core/back9/dto/ScoreDTO.java
@@ -14,22 +14,32 @@ public class ScoreDTO {
 	@NoArgsConstructor
 	@Builder
 	@Getter
-	public static class RegisterRequest {
-		private int score;
-		private String comment;
+	public static class CreateResponse {
+		private Long id;
+		private Long roomId;
 		private RatingType ratingType;
+		private LocalDateTime createdAt;
 	}
 
 	@AllArgsConstructor
 	@NoArgsConstructor
 	@Builder
 	@Getter
-	public static class RegisterResponse {
+	public static class UpdateRequest {
+		private int score;
+		private String comment;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class UpdateResponse {
 		private Long id;
 		private int score;
 		private String comment;
 		private RatingType ratingType;
-		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
 	}
 
 	@AllArgsConstructor

--- a/src/main/java/com/core/back9/entity/Score.java
+++ b/src/main/java/com/core/back9/entity/Score.java
@@ -1,6 +1,7 @@
 package com.core.back9.entity;
 
 import com.core.back9.common.entity.BaseEntity;
+import com.core.back9.dto.ScoreDTO;
 import com.core.back9.entity.constant.RatingType;
 import com.core.back9.entity.constant.Status;
 import jakarta.persistence.*;
@@ -50,4 +51,10 @@ public class Score extends BaseEntity {
 		this.member = member;
 		this.status = status;
 	}
+
+	public void updateScore(ScoreDTO.UpdateRequest updateRequest) {
+		this.score = updateRequest.getScore();
+		this.comment = updateRequest.getComment();
+	}
+
 }

--- a/src/main/java/com/core/back9/entity/Tenant.java
+++ b/src/main/java/com/core/back9/entity/Tenant.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -25,6 +27,9 @@ public class Tenant extends BaseEntity {
 	@Column
 	private Status status;
 
+	@OneToMany(mappedBy = "tenant", cascade = CascadeType.REMOVE)
+	private List<Member> members;
+
 	@Builder
 	private Tenant(String name, String companyNumber) {
 		this.name = name;
@@ -38,4 +43,9 @@ public class Tenant extends BaseEntity {
 		this.status = Status.REGISTER;
 		return this;
 	}
+
+	public void addMember(Member member) {
+		this.members.add(member);
+	}
+
 }

--- a/src/main/java/com/core/back9/entity/constant/RatingType.java
+++ b/src/main/java/com/core/back9/entity/constant/RatingType.java
@@ -1,4 +1,7 @@
 package com.core.back9.entity.constant;
 
 public enum RatingType {
+
+	FACILITY, MANAGEMENT, COMPLAINT
+
 }

--- a/src/main/java/com/core/back9/mapper/ScoreMapper.java
+++ b/src/main/java/com/core/back9/mapper/ScoreMapper.java
@@ -13,9 +13,9 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface ScoreMapper {
 
-	Score toEntity(ScoreDTO.RegisterRequest registerRequest);
+	Score toEntity(ScoreDTO.UpdateRequest updateRequest);
 
-	ScoreDTO.RegisterResponse toRegisterResponse(Score score);
+	ScoreDTO.UpdateResponse toUpdateResponse(Score score);
 
 	ScoreDTO.Info toInfo(Score score);
 

--- a/src/main/java/com/core/back9/repository/ScoreRepository.java
+++ b/src/main/java/com/core/back9/repository/ScoreRepository.java
@@ -1,0 +1,21 @@
+package com.core.back9.repository;
+
+import com.core.back9.entity.Score;
+import com.core.back9.exception.ApiErrorCode;
+import com.core.back9.exception.ApiException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ScoreRepository extends JpaRepository<Score, Long> {
+
+	Optional<Score> findFirstByIdAndMemberIdAndRoomId(Long scoreId, Long memberId, Long roomId);
+
+	default Score getValidScoreWithIdAndMemberIdAndRoomId(Long scoreId, Long memberId, Long roomId) {
+		return findFirstByIdAndMemberIdAndRoomId(scoreId, memberId, roomId)
+		  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_EVALUATION));
+	}
+
+}

--- a/src/main/java/com/core/back9/service/ScoreService.java
+++ b/src/main/java/com/core/back9/service/ScoreService.java
@@ -62,7 +62,8 @@ public class ScoreService {
 
 		if (member.getRole() == Role.OWNER) {
 			/* 유효한 호실 */
-			Room validRoom = roomRepository.getValidRoomWithIdOrThrow(buildingId, roomId, Status.REGISTER);
+			Room validRoom = roomRepository.getRoomBySpecificIds(buildingId, roomId, member.getId(), Status.REGISTER)
+			  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_ROOM));
 
 			/* 유효한 입주사 -> 필요가 없넹 */
 //			Tenant validTenant = tenantRepository.getValidOneTenantOrThrow(createRequest.getTenantId());

--- a/src/main/java/com/core/back9/service/ScoreService.java
+++ b/src/main/java/com/core/back9/service/ScoreService.java
@@ -1,0 +1,123 @@
+package com.core.back9.service;
+
+import com.core.back9.dto.MemberDTO;
+import com.core.back9.dto.ScoreDTO;
+import com.core.back9.entity.Contract;
+import com.core.back9.entity.Room;
+import com.core.back9.entity.Score;
+import com.core.back9.entity.constant.ContractStatus;
+import com.core.back9.entity.constant.RatingType;
+import com.core.back9.entity.constant.Role;
+import com.core.back9.entity.constant.Status;
+import com.core.back9.exception.ApiErrorCode;
+import com.core.back9.exception.ApiException;
+import com.core.back9.mapper.ScoreMapper;
+import com.core.back9.repository.MemberRepository;
+import com.core.back9.repository.RoomRepository;
+import com.core.back9.repository.ScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ScoreService {
+
+	private final MemberRepository memberRepository;
+	//	private final TenantRepository tenantRepository;
+	private final RoomRepository roomRepository;
+	private final ScoreRepository scoreRepository;
+	private final ScoreMapper scoreMapper;
+
+	public void create(
+	  MemberDTO.Info member,
+	  Long buildingId,
+	  Long roomId,
+	  RatingType ratingType
+	) {
+		/* TODO 평가 레코드 생성 조건 붙이기,
+		    batch 생성이라면 멤버(OWNER) 권한은 필요없음
+		    예외적으로 로그인 멤버가 OWNER 상태일 때 수동으로 발생
+		*/
+
+		/*
+		첫번째 작업 - 코딩 중 예외상황이 많이 확인되어 철회
+		해당 호실과 인증된 유저로 평가 레코드가 생성될 수 있는지 확인 후 생성
+		1. 해당 호실의 계약목록이 있는지
+		2. 계약목록이 있다면 마지막 계약이 진행중인 계약인지
+		3. 진행중인 계약의 입주사에 포함된 유저인지
+
+		생각해볼 문제: 1차적인 생각으로 위의 조건으로 생성을 했는데
+		 1. 계약목록이 4건이 있는데 4번째 계약은 대기 상태이고 유저는 3번째 계약 진행중인 입주사에 포함되어 있을 때
+		 -> 무조건 마지막 계약이 진행중인지 확인하는건 오류 가능성이 있음
+		 TODO 2. 평가를 진행 할 수 있는 유효기간이 필요함
+		  -> 4월 1일에 발생한 평가를 진행하지 않고 7월 1일이 되었을 때
+		 3. 평가 레코드 생성은 시설/관리는 입주사 기준으로 생성이 되고, 민원은 유저 기준으로 생성되어야 함
+		 4. 다 필요없고 빌딩-호실에서 수동으로 평가를 발생시키려면 평가타입만 선택하면 계약 이행중인 입주사에 바로 실행
+		 TODO 5. 평가 레코드 타입에 대해 생성일 체크하여 중복생성 방지해야함 (시설-분기별, 관리-월별, 민원-건별)
+		 */
+
+		if (member.getRole() == Role.OWNER) {
+			/* 유효한 호실 */
+			Room validRoom = roomRepository.getValidRoomWithIdOrThrow(buildingId, roomId, Status.REGISTER);
+
+			/* 유효한 입주사 -> 필요가 없넹 */
+//			Tenant validTenant = tenantRepository.getValidOneTenantOrThrow(createRequest.getTenantId());
+
+			/* 해당 호실의 계약 목록 */
+			List<Contract> contracts = validRoom.getContracts();
+
+			/* 계약 목록 중 계약 이행중인 입주사
+			 * 이행중인 계약은 단 한건이라고 판단 -> findFirst -> 없다면 계약 이행중인 상태가 아니다! */
+			Contract progressContract = contracts.stream().filter(contract -> contract.getContractStatus() == ContractStatus.IN_PROGRESS)
+			  .findFirst().orElseThrow(() -> new ApiException(ApiErrorCode.CONTRACT_NOT_IN_PROGRESS));
+
+			/* 계약 이행 중인 입주사에 포함된 모든 사용자에게 평가 레코드 생성 (평가타입은 리퀘스트로 받음) */
+			progressContract.getTenant().getMembers().forEach(user -> {
+				try {
+					memberRepository.findFirstByIdAndRoleAndStatus(user.getId(), Role.USER, Status.REGISTER)
+					  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_MEMBER, "평가 레코드를 생성할 수 없는 사용자입니다"));
+					Score newScore = Score.builder()
+					  .score(0)
+					  .comment("")
+					  .bookmark(false)
+					  .ratingType(ratingType)
+					  .room(validRoom)
+					  .member(user)
+					  .status(Status.REGISTER)
+					  .build();
+					scoreRepository.save(newScore);
+				} catch (ApiException apiException) {
+					System.out.printf("평가 레코드 생성 실패 사용자 id: %s, role: %s, status: %s%n", user.getId(), user.getRole(), user.getStatus());
+				}
+			});
+			return;
+
+
+		}
+		throw new ApiException(ApiErrorCode.DO_NOT_HAVE_PERMISSION, "평가 수동 발생은 소유자의 권한입니다");
+	}
+
+	public ScoreDTO.UpdateResponse update(
+	  MemberDTO.Info member,    // USER
+	  Long scoreId,
+	  Long roomId,
+	  ScoreDTO.UpdateRequest updateRequest
+	) {
+		Score validScore = scoreRepository.getValidScoreWithIdAndMemberIdAndRoomId(scoreId, member.getId(), roomId);
+		validScore.updateScore(updateRequest);
+		return scoreMapper.toUpdateResponse(validScore);
+	}
+
+	/* TODO 마지막 계약을 가져오는 건 검증의 조건이 될 수 없음, 내일 아침에 당장 바까라
+	    차라리 계약 이행중인 입주사 하나만 빼오는게 좋음 (유일한 상태 값) -> 계약 도메인이 완전한 상태라면 */
+//	private boolean isPossible(List<Contract> contracts, Tenant validTenant) {
+//		return !contracts.isEmpty()
+//		  && contracts.get(contracts.size() - 1).getContractStatus() != ContractStatus.IN_PROGRESS
+//		  && Objects.equals(contracts.get(contracts.size() - 1).getTenant().getId(), validTenant.getId());
+//	}
+
+}


### PR DESCRIPTION
## 📝작업 내용
> 평가 서비스, 레포 생성
> 평가진행은 생성이 아니라 변경의 개념이라 DTO,매퍼 이름 변경
> 입주사에 입주자 목록 필드 추가
> 평가 레코드 수동 생성 구현 시나리오
-> 소유자가 본인이 소유중인 호실에 대해 평가타입(민원, 시설)을 지정한 후 발생 (배치로 자동생성 할 때는 고려할 필요 없음)
-> 검증 사항
> 1. 해당 호실이 유효한가 (유효한 호실이면서 요청한 소유자의 것인지 포함)
> 2. 계약이 이행중인가
> 3. 계약을 이행중인 입주사의 모든 입주자를 대상으로 생성

## #️⃣연관된 이슈
> closed : #84

## 💬리뷰 요구사항(선택)
> 수동 평가 생성과 진행 엔드포인트를 구분하려고 합니다. (평가 생성의 주체는 소유자이고 평가 진행의 주체는 입주자이기때문에)
> 호실에 많은 작업이 몰리다 보니 의존성도 많이 추가되는 상황이라 고민해보고 평가에 대한 서비스를 분리했습니다.
> 입주사의 모든 입주자에게 평가 레코드를 생성하는 과정에서 유효한 입주자인지 체크하는 부분을 넣었는데 필요한건지 애매합니다.
> 예를 들어 입주사에 포함되어 있지만 탈퇴를 하여 평가가 불가한 상황 -> 하지만 로그인도 되지 않으니 필터가 필요할까?
> 일단 생성하는 부분 api 테스트만 완료하고 PR 남깁니다. 평가진행 서비스는 작성했지만 멤버 컨트롤러에서 호출할 예정입니다.