### PR TITLE
평가 관련 추가 구현

### DIFF
--- a/src/main/java/com/core/back9/controller/MemberController.java
+++ b/src/main/java/com/core/back9/controller/MemberController.java
@@ -1,13 +1,6 @@
 package com.core.back9.controller;
 
-import com.core.back9.dto.MemberDTO;
-import com.core.back9.service.MemberService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,19 +8,5 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/members")
 public class MemberController {
-
-    private final MemberService memberService;
-
-//    @PreAuthorize("hasAnyAuthority('USER', 'OWNER','ADMIN')")
-//    @GetMapping("/info")
-//    public ResponseEntity<MemberDTO.Info> getCurrentMemberInfo(HttpServletRequest request) {
-//        return ResponseEntity.ok(memberService.getCurrenMemberInfo());
-//    }
-//
-//    @PreAuthorize("hasAnyAuthority('ADMIN')")
-//    @GetMapping("/info/{email}")
-//    public ResponseEntity<MemberDTO.Info> getMemberInfo(@PathVariable String email) {
-//        return ResponseEntity.ok(memberService.getMemberInfo(email));
-//    }
 
 }

--- a/src/main/java/com/core/back9/controller/ScoreController.java
+++ b/src/main/java/com/core/back9/controller/ScoreController.java
@@ -1,0 +1,43 @@
+package com.core.back9.controller;
+
+import com.core.back9.dto.MemberDTO;
+import com.core.back9.dto.ScoreDTO;
+import com.core.back9.security.AuthMember;
+import com.core.back9.service.ScoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/scores")
+public class ScoreController {
+
+	private final ScoreService scoreService;
+
+	@PatchMapping("/{scoreId}")
+	public ResponseEntity<ScoreDTO.UpdateResponse> updateEvaluation(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long scoreId,
+	  @RequestBody ScoreDTO.UpdateRequest updateRequest
+	) {
+		return ResponseEntity.ok(scoreService.updateScore(member, scoreId, updateRequest));
+	}
+
+	@PatchMapping("/{scoreId}/bookmark-add")
+	public ResponseEntity<ScoreDTO.Info> addBookmark(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long scoreId
+	) {
+		return ResponseEntity.ok(scoreService.updateBookmark(member, scoreId, true));
+	}
+
+	@PatchMapping("/{scoreId}/bookmark-remove")
+	public ResponseEntity<ScoreDTO.Info> removeBookmark(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long scoreId
+	) {
+		return ResponseEntity.ok(scoreService.updateBookmark(member, scoreId, false));
+	}
+
+}

--- a/src/main/java/com/core/back9/dto/DateDTO.java
+++ b/src/main/java/com/core/back9/dto/DateDTO.java
@@ -1,0 +1,28 @@
+package com.core.back9.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+public class DateDTO {
+
+	private int year;
+	private int month;
+	private int quarter;
+	private int startMonth;
+	private int endMonth;
+
+	@Builder
+	public DateDTO(int year, int month, int quarter, int startMonth, int endMonth) {
+		this.year = year;
+		this.month = month;
+		this.quarter = quarter;
+		this.startMonth = startMonth;
+		this.endMonth = endMonth;
+	}
+
+}

--- a/src/main/java/com/core/back9/entity/Member.java
+++ b/src/main/java/com/core/back9/entity/Member.java
@@ -49,7 +49,7 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member") // 양방향 설정
     private List<Score> scores = new ArrayList<>();
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @JoinColumn(name = "tenant_id")
     private Tenant tenant;
 

--- a/src/main/java/com/core/back9/entity/Score.java
+++ b/src/main/java/com/core/back9/entity/Score.java
@@ -57,4 +57,8 @@ public class Score extends BaseEntity {
 		this.comment = updateRequest.getComment();
 	}
 
+	public void updateBookmark(boolean bookmark) {
+		this.bookmark = bookmark;
+	}
+
 }

--- a/src/main/java/com/core/back9/entity/Tenant.java
+++ b/src/main/java/com/core/back9/entity/Tenant.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,8 +28,10 @@ public class Tenant extends BaseEntity {
 	@Column
 	private Status status;
 
-	@OneToMany(mappedBy = "tenant", cascade = CascadeType.REMOVE)
-	private List<Member> members;
+	@OneToMany(mappedBy = "tenant",
+	  cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+	  fetch = FetchType.LAZY)
+	private final List<Member> members = new ArrayList<>();
 
 	@Builder
 	private Tenant(String name, String companyNumber) {
@@ -44,8 +47,5 @@ public class Tenant extends BaseEntity {
 		return this;
 	}
 
-	public void addMember(Member member) {
-		this.members.add(member);
-	}
 
 }

--- a/src/main/java/com/core/back9/exception/ApiErrorCode.java
+++ b/src/main/java/com/core/back9/exception/ApiErrorCode.java
@@ -29,6 +29,7 @@ public enum ApiErrorCode {
     NOT_BEARER_TOKEN(HttpStatus.BAD_REQUEST.value(), "BEARER 토큰이 아닙니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST.value(), "잘못된 JWT입니다."),
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST.value(), "만료된 JWT입니다."),
+	ALREADY_COMPLETED_EVALUATION(HttpStatus.BAD_REQUEST.value(), "이미 완료된 평가입니다."),
 
 	THREAD_POOL_REJECTED(HttpStatus.REQUEST_TIMEOUT.value(), "더 이상 요청을 처리 할 수 없습니다"),
 

--- a/src/main/java/com/core/back9/repository/ScoreRepository.java
+++ b/src/main/java/com/core/back9/repository/ScoreRepository.java
@@ -1,9 +1,12 @@
 package com.core.back9.repository;
 
 import com.core.back9.entity.Score;
+import com.core.back9.entity.constant.Status;
 import com.core.back9.exception.ApiErrorCode;
 import com.core.back9.exception.ApiException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,11 +14,34 @@ import java.util.Optional;
 @Repository
 public interface ScoreRepository extends JpaRepository<Score, Long> {
 
-	Optional<Score> findFirstByIdAndMemberIdAndRoomId(Long scoreId, Long memberId, Long roomId);
+	Optional<Score> findFirstByIdAndMemberIdAndStatus(Long scoreId, Long memberId, Status status);
 
-	default Score getValidScoreWithIdAndMemberIdAndRoomId(Long scoreId, Long memberId, Long roomId) {
-		return findFirstByIdAndMemberIdAndRoomId(scoreId, memberId, roomId)
+	default Score getValidScoreWithIdAndMemberIdAndStatus(Long scoreId, Long memberId, Status status) {
+		return findFirstByIdAndMemberIdAndStatus(scoreId, memberId, status)
 		  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_EVALUATION));
 	}
+
+	@Query("SELECT COUNT(s) = 0 FROM Score s WHERE " +
+	  "YEAR(s.createdAt) = :year AND " +
+	  "MONTH(s.createdAt) BETWEEN :startMonth AND :endMonth AND " +
+	  "s.member.id = :memberId AND " +
+	  "s.room.id = :roomId AND " +
+	  "s.ratingType = 'FACILITY'")
+	boolean existsByYearAndQuarterAndMemberIdAndRoomId(@Param("year") int year,
+													   @Param("startMonth") int startMonth,
+													   @Param("endMonth") int endMonth,
+													   @Param("memberId") Long memberId,
+													   @Param("roomId") Long roomId);
+
+	@Query("SELECT COUNT(s) = 0 FROM Score s WHERE " +
+	  "YEAR(s.createdAt) = :year AND " +
+	  "MONTH(s.createdAt) = :currentMonth AND " +
+	  "s.member.id = :memberId AND " +
+	  "s.room.id = :roomId AND " +
+	  "s.ratingType = 'MANAGEMENT'")
+	boolean existsByYearAndMonthAndMemberIdAndRoomId(@Param("year") int year,
+													 @Param("currentMonth") int currentMonth,
+													 @Param("memberId") Long memberId,
+													 @Param("roomId") Long roomId);
 
 }

--- a/src/main/java/com/core/back9/util/DateUtils.java
+++ b/src/main/java/com/core/back9/util/DateUtils.java
@@ -1,0 +1,102 @@
+package com.core.back9.util;
+
+import com.core.back9.dto.DateDTO;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.List;
+
+@NoArgsConstructor
+public class DateUtils {
+
+	protected LocalDate localDate = LocalDate.now();
+
+	public DateUtils(LocalDate localDate) {
+		this.localDate = localDate;
+	}
+
+	public int getYear() {
+		return localDate.getYear();
+	}
+
+	public int getYear(LocalDate localDate) {
+		return localDate.getYear();
+	}
+
+	public int getMonth() {
+		return localDate.getMonth().getValue();
+	}
+
+	public int getMonth(LocalDate localDate) {
+		return localDate.getMonth().getValue();
+	}
+
+	public int getQuarter(LocalDate... localDate) {
+		LocalDate date = Arrays.stream(localDate).findFirst().orElseGet(() -> this.localDate);
+		Month month = date.getMonth();
+		if (month.getValue() <= 3) {
+			return 1;
+		} else if (month.getValue() <= 6) {
+			return 2;
+		} else if (month.getValue() <= 9) {
+			return 3;
+		} else {
+			return 4;
+		}
+	}
+
+	public int getStartMonth(int quarter) {
+		return switch (quarter) {
+			case 1 -> 1;
+			case 2 -> 4;
+			case 3 -> 7;
+			default -> 10;
+		};
+	}
+
+	public int getEndMonth(int quarter) {
+		return switch (quarter) {
+			case 1 -> 3;
+			case 2 -> 6;
+			case 3 -> 9;
+			default -> 12;
+		};
+	}
+
+	public DateDTO getYearAndQuarter(LocalDate... localDate) {
+		LocalDate date = Arrays.stream(localDate).findFirst().orElseGet(() -> this.localDate);
+		return DateDTO.builder()
+		  .year(date.getYear())
+		  .quarter(getQuarter(date))
+		  .build();
+	}
+
+	public DateDTO getStartAndEndMonths(LocalDate... localDate) {
+		LocalDate date = Arrays.stream(localDate).findFirst().orElseGet(() -> this.localDate);
+		return DateDTO.builder()
+		  .startMonth(getQuarter(date))
+		  .endMonth(getQuarter(date))
+		  .build();
+	}
+
+	public DateDTO allParameters(LocalDate... localDate) {
+		LocalDate date = Arrays.stream(localDate).findFirst().orElseGet(() -> this.localDate);
+		return DateDTO.builder()
+		  .year(date.getYear())
+		  .month(getMonth(date))
+		  .quarter(getQuarter(date))
+		  .startMonth(getQuarter(date))
+		  .endMonth(getQuarter(date))
+		  .build();
+	}
+
+	public boolean hasDataWithinTwoYears(List<LocalDateTime> updatedAts) {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime twoYearsAgo = now.minusYears(2);
+		return updatedAts.stream().anyMatch(updatedAt -> !updatedAt.isBefore(twoYearsAgo));
+	}
+
+}

--- a/src/test/java/com/core/back9/repository/ScoreRepositoryTest.java
+++ b/src/test/java/com/core/back9/repository/ScoreRepositoryTest.java
@@ -1,0 +1,125 @@
+package com.core.back9.repository;
+
+import com.core.back9.common.config.AuditingConfig;
+import com.core.back9.dto.ScoreDTO;
+import com.core.back9.entity.Building;
+import com.core.back9.entity.Member;
+import com.core.back9.entity.Room;
+import com.core.back9.entity.Score;
+import com.core.back9.entity.constant.RatingType;
+import com.core.back9.entity.constant.Role;
+import com.core.back9.entity.constant.Status;
+import com.core.back9.entity.constant.Usage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(value = AuditingConfig.class)
+class ScoreRepositoryTest {
+
+	@Autowired
+	private ScoreRepository scoreRepository;
+
+	@Autowired
+	private RoomRepository roomRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private Score score;
+	private Building building;
+	private Room room;
+	private Member admin;
+	private Member owner;
+	private Member user;
+
+	@BeforeEach
+	public void initSetting() {
+		admin = Member.builder()
+		  .email("admin@gmail.com")
+		  .role(Role.ADMIN)
+		  .status(Status.REGISTER)
+		  .build();
+		memberRepository.save(admin);
+		owner = Member.builder()
+		  .email("owner@gmail.com")
+		  .role(Role.OWNER)
+		  .status(Status.REGISTER)
+		  .build();
+		memberRepository.save(owner);
+		user = Member.builder()
+		  .email("user@gmail.com")
+		  .role(Role.USER)
+		  .status(Status.REGISTER)
+		  .build();
+		memberRepository.save(user);
+
+		room = Room.builder()
+		  .building(building)
+		  .name("room name 1")
+		  .floor("room floor 1")
+		  .area(84F)
+		  .usage(Usage.OFFICES)
+		  .member(owner)
+		  .build();
+		roomRepository.save(room);
+	}
+
+	@Test
+	public void givenScoreEntityWhenSaveScore() {
+		Score newScore = Score.builder()
+		  .score(0)
+		  .comment("")
+		  .bookmark(false)
+		  .ratingType(RatingType.FACILITY)
+		  .room(room)
+		  .member(user)
+		  .status(Status.REGISTER)
+		  .build();
+
+		Score savedScore = scoreRepository.save(newScore);
+		assertThat(savedScore).isNotNull();
+		assertThat(savedScore.getScore()).isEqualTo(newScore.getScore());
+		assertThat(savedScore.getRatingType()).isEqualTo(newScore.getRatingType());
+		assertThat(savedScore.getRoom().getMember()).isEqualTo(owner);
+		assertThat(savedScore.getMember()).isEqualTo(user);
+	}
+
+	@Test
+	public void givenUpdateRequestWhenUpdateEntityThenUpdateResponse() {
+		Score newScore = Score.builder()
+		  .score(0)
+		  .comment("")
+		  .bookmark(false)
+		  .ratingType(RatingType.FACILITY)
+		  .room(room)
+		  .member(user)
+		  .status(Status.REGISTER)
+		  .build();
+
+		Score savedScore = scoreRepository.save(newScore);
+		long savedScoreId = savedScore.getId();
+
+		ScoreDTO.UpdateRequest request = ScoreDTO.UpdateRequest.builder()
+		  .score(90)
+		  .comment("hello")
+		  .build();
+
+		Score validScore = scoreRepository.getValidScoreWithIdAndMemberIdAndStatus(savedScoreId, user.getId(), Status.REGISTER);
+		validScore.updateScore(request);
+
+		assertThat(validScore).isNotNull();
+		assertThat(validScore.getScore()).isEqualTo(request.getScore());
+		assertThat(validScore.getComment()).isEqualTo(request.getComment());
+	}
+
+}

--- a/src/test/java/com/core/back9/service/RoomServiceTest.java
+++ b/src/test/java/com/core/back9/service/RoomServiceTest.java
@@ -135,7 +135,7 @@ class RoomServiceTest {
 
 		RoomDTO.Response result = roomService.create(admin, building.getId(), request);
 
-		assertThat(result).isEqualTo(result);
+		assertThat(result).isEqualTo(response);
 		verify(buildingRepository).getValidBuildingWithIdOrThrow(building.getId(), Status.REGISTER);
 		verify(roomMapper).toEntity(building, request, setting);
 		verify(roomRepository).save(room);

--- a/src/test/java/com/core/back9/service/ScoreServiceTest.java
+++ b/src/test/java/com/core/back9/service/ScoreServiceTest.java
@@ -1,0 +1,15 @@
+package com.core.back9.service;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class ScoreServiceTest {
+
+
+}


### PR DESCRIPTION
## 📝작업 내용
> 완료된 평가에 접근 예외 코드 추가
> 날짜 관련 유틸과 DTO 생성
> 멤버 엔티티가 포함한 입주사 즉시 로딩으로 변경
> 평가 컨트롤러 생성 -> 평가 진행, 평가 북마크 구현
> 평가 생성 조건 쿼리 추가
> 평가 레포 테스트 (create, update)
> 그외 코드 정렬

## #️⃣연관된 이슈
> closed : #87

## 💬리뷰 요구사항(선택)
> 날짜 관련 유틸 내용입니다.
> 1. 기본생성자 사용하면 기준은 현재시간입니다.
> 2. 생성자에 LocalDate 지정 가능합니다.
> 3. 기준 년,월,분기 반환 메서드가 있고, 분기 반환 타입은 int이고 값은 1, 2, 3, 4가 됩니다.
> 4. getStartMonth(int quarter), getEndMonth(int quarter) 두 개의 메서드는 지정된 분기의 시작월과 종료월입니다.
> ex) 2분기의 시작월은 4, 종료월은 6
> 5. 최근 2년간의 평가데이터 유무를 확인하는 메서드 추가했습니다. (쿼리로 처리하는 방법도 있지만 생각난김에 만들..)
> 시나리오에 따라 사용유무를 정하면 되겠습니다.
```
public boolean hasDataWithinTwoYears(List<LocalDateTime> updatedAts)
```
