### PR TITLE
빌딩, 호실 컨트롤러 분리

### DIFF
--- a/src/main/java/com/core/back9/controller/BuildingController.java
+++ b/src/main/java/com/core/back9/controller/BuildingController.java
@@ -6,7 +6,6 @@ import com.core.back9.security.AuthMember;
 import com.core.back9.service.BuildingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,21 +24,6 @@ public class BuildingController {
 	  @RequestBody BuildingDTO.Request request
 	) {
 		return ResponseEntity.ok(buildingService.create(member, request));
-	}
-
-	@GetMapping("")
-	public ResponseEntity<Page<BuildingDTO.Info>> getAll(
-	  Pageable pageable
-	) {
-		return ResponseEntity.ok(buildingService.selectAll(pageable));
-	}
-
-	@GetMapping("/{buildingId}")
-	public ResponseEntity<BuildingDTO.Info> getOne(
-	  @PathVariable Long buildingId,
-	  Pageable pageable
-	) {
-		return ResponseEntity.ok(buildingService.selectOne(buildingId, pageable));
 	}
 
 	@PatchMapping("/{buildingId}")

--- a/src/main/java/com/core/back9/controller/OwnerBuildingController.java
+++ b/src/main/java/com/core/back9/controller/OwnerBuildingController.java
@@ -1,0 +1,40 @@
+package com.core.back9.controller;
+
+import com.core.back9.dto.BuildingDTO;
+import com.core.back9.dto.MemberDTO;
+import com.core.back9.security.AuthMember;
+import com.core.back9.service.BuildingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/buildings")
+@RestController
+public class OwnerBuildingController {
+
+	private final BuildingService buildingService;
+
+	@GetMapping("")
+	public ResponseEntity<Page<BuildingDTO.Info>> getAll(
+	  @AuthMember MemberDTO.Info member,
+	  Pageable pageable
+	) {
+		return ResponseEntity.ok(buildingService.selectAll(member, pageable));
+	}
+
+	@GetMapping("/{buildingId}")
+	public ResponseEntity<BuildingDTO.Info> getOne(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  Pageable pageable
+	) {
+		return ResponseEntity.ok(buildingService.selectOne(member, buildingId, pageable));
+	}
+
+}

--- a/src/main/java/com/core/back9/controller/OwnerRoomController.java
+++ b/src/main/java/com/core/back9/controller/OwnerRoomController.java
@@ -1,0 +1,90 @@
+package com.core.back9.controller;
+
+import com.core.back9.dto.MemberDTO;
+import com.core.back9.dto.RoomDTO;
+import com.core.back9.entity.constant.RatingType;
+import com.core.back9.security.AuthMember;
+import com.core.back9.service.RoomService;
+import com.core.back9.service.ScoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/buildings/{buildingId}/rooms")
+@RestController
+public class OwnerRoomController {
+
+	private final RoomService roomService;
+	private final ScoreService scoreService;
+
+	@GetMapping("")    // 대시보드에서 호실 목록 보여줄 때
+	public ResponseEntity<Page<RoomDTO.Info>> getAll(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  Pageable pageable
+	) {
+		return ResponseEntity.ok(roomService.selectAll(member, buildingId, pageable));
+	}
+
+	@GetMapping("/{roomId}")
+	public ResponseEntity<RoomDTO.Info> getOne(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId
+	) {
+		return ResponseEntity.ok(roomService.selectOne(member, buildingId, roomId));
+	}
+
+	@PostMapping("/{roomId}/setting-on")
+	public ResponseEntity<RoomDTO.Info> turnOn(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId
+	) {
+		return ResponseEntity.ok(roomService.updateSwitch(member, buildingId, roomId, true));
+	}
+
+	@PostMapping("/{roomId}/setting-off")
+	public ResponseEntity<RoomDTO.Info> turnOff(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId
+	) {
+		return ResponseEntity.ok(roomService.updateSwitch(member, buildingId, roomId, false));
+	}
+
+	@PatchMapping("/{roomId}/modify-encourage-message")
+	public ResponseEntity<RoomDTO.Info> modify(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId,
+	  @RequestBody String encourageMessage
+	) {
+		return ResponseEntity.ok(roomService.updateEncourageMessage(member, buildingId, roomId, encourageMessage));
+	}
+
+	@PatchMapping("/{roomId}/setting-represent")
+	public ResponseEntity<Page<RoomDTO.Info>> modifyRepresent(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId,
+	  Pageable pageable
+	) {
+		return ResponseEntity.ok(roomService.updateRepresent(member, buildingId, roomId, pageable));
+	}
+
+	@PatchMapping("/{roomId}/scores-generate")
+	public void evaluation(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId,
+	  @RequestParam RatingType ratingType
+	) {
+		// 빌딩-호실에 대해 현재 계약중인 입주사에 평가를 수동으로 발생
+		scoreService.create(member, buildingId, roomId, ratingType);
+	}
+
+}

--- a/src/main/java/com/core/back9/controller/RoomController.java
+++ b/src/main/java/com/core/back9/controller/RoomController.java
@@ -2,14 +2,11 @@ package com.core.back9.controller;
 
 import com.core.back9.dto.MemberDTO;
 import com.core.back9.dto.RoomDTO;
-import com.core.back9.entity.constant.RatingType;
 import com.core.back9.security.AuthMember;
 import com.core.back9.service.RoomService;
 import com.core.back9.service.ScoreService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -51,50 +48,6 @@ public class RoomController {
 		return ResponseEntity.ok(roomService.delete(member, buildingId, roomId));
 	}
 
-	@GetMapping("")	// 대시보드에서 호실 목록 보여줄 때
-	public ResponseEntity<Page<RoomDTO.Info>> getAll(
-	  @PathVariable Long buildingId,
-	  Pageable pageable
-	) {
-		return ResponseEntity.ok(roomService.selectAll(buildingId, pageable));
-	}
-
-	@GetMapping("/{roomId}")
-	public ResponseEntity<RoomDTO.Info> getOne(
-	  @PathVariable Long buildingId,
-	  @PathVariable Long roomId
-	) {
-		return ResponseEntity.ok(roomService.selectOne(buildingId, roomId));
-	}
-
-	@PostMapping("/{roomId}/setting-on")
-	public ResponseEntity<RoomDTO.Info> turnOn(
-	  @AuthMember MemberDTO.Info member,
-	  @PathVariable Long buildingId,
-	  @PathVariable Long roomId
-	) {
-		return ResponseEntity.ok(roomService.updateSwitch(member, buildingId, roomId, true));
-	}
-
-	@PostMapping("/{roomId}/setting-off")
-	public ResponseEntity<RoomDTO.Info> turnOff(
-	  @AuthMember MemberDTO.Info member,
-	  @PathVariable Long buildingId,
-	  @PathVariable Long roomId
-	) {
-		return ResponseEntity.ok(roomService.updateSwitch(member, buildingId, roomId, false));
-	}
-
-	@PatchMapping("/{roomId}/modify-encourage-message")
-	public ResponseEntity<RoomDTO.Info> modify(
-	  @AuthMember MemberDTO.Info member,
-	  @PathVariable Long buildingId,
-	  @PathVariable Long roomId,
-	  @RequestBody String encourageMessage
-	) {
-		return ResponseEntity.ok(roomService.updateEncourageMessage(member, buildingId, roomId, encourageMessage));
-	}
-
 	@PatchMapping("/{roomId}/owners/{ownerId}")
 	public ResponseEntity<RoomDTO.InfoWithOwner> giveRoom(
 	  @AuthMember MemberDTO.Info member,
@@ -103,27 +56,6 @@ public class RoomController {
 	  @PathVariable Long ownerId
 	) {
 		return ResponseEntity.ok(roomService.settingOwner(member, buildingId, roomId, ownerId));
-	}
-
-	@PatchMapping("/{roomId}/setting-represent")
-	public ResponseEntity<Page<RoomDTO.Info>> modifyRepresent(
-	  @AuthMember MemberDTO.Info member,
-	  @PathVariable Long buildingId,
-	  @PathVariable Long roomId,
-	  Pageable pageable
-	) {
-		return ResponseEntity.ok(roomService.updateRepresent(member, buildingId, roomId, pageable));
-	}
-
-	@PatchMapping("/{roomId}/scores-generate")
-	public void evaluation(
-	  @AuthMember MemberDTO.Info member,
-	  @PathVariable Long buildingId,
-	  @PathVariable Long roomId,
-	  @RequestParam RatingType ratingType
-	) {
-		// 빌딩-호실에 대해 현재 계약중인 입주사에 평가를 수동으로 발생
-		scoreService.create(member, buildingId, roomId, ratingType);
 	}
 
 }

--- a/src/main/java/com/core/back9/repository/BuildingRepository.java
+++ b/src/main/java/com/core/back9/repository/BuildingRepository.java
@@ -7,6 +7,8 @@ import com.core.back9.exception.ApiException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -22,5 +24,31 @@ public interface BuildingRepository extends JpaRepository<Building, Long> {
 	}
 
 	Page<Building> findAllByStatus(Status status, Pageable pageable);
+
+	@Query(
+	  """
+		SELECT b FROM Building b 
+		JOIN FETCH b.roomList r 
+		WHERE b.id = :buildingId 
+		AND r.member.id = :memberId
+		"""
+	)
+	Optional<Building> findFirstBuildingWithRoomsByBuildingIdAndMemberId(
+	  @Param("buildingId") Long buildingId, @Param("memberId") Long memberId
+	);
+
+	default Building findValidBuildingWithRoomsByBuildingIdAndMemberId(Long buildingId, Long memberId) {
+		return findFirstBuildingWithRoomsByBuildingIdAndMemberId(buildingId, memberId)
+		  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_BUILDING));
+	}
+
+	@Query(
+	  """
+		SELECT b FROM Building b
+		JOIN FETCH b.roomList r
+		WHERE r.member.id = :memberId
+		"""
+	)
+	Page<Building> findAllBuildingWithRoomsByBuildingIdAndMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
 }

--- a/src/main/java/com/core/back9/repository/RoomRepository.java
+++ b/src/main/java/com/core/back9/repository/RoomRepository.java
@@ -40,6 +40,8 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
 	Page<Room> findAllByBuildingIdAndStatus(Long buildingId, Status status, Pageable pageable);
 
+	Page<Room> findAllByBuildingIdAndMemberIdAndStatus(Long buildingId, Long memberId, Status status, Pageable pageable);
+
 	@Query(
 	  """
 		SELECT COUNT(r) = 0 
@@ -49,7 +51,7 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 		AND r.represent = true
 		"""
 	)
-	boolean existsRepresentRoom(@Param("buildingId") Long buildingId, @Param("memberId") Long memberId);
+	boolean notExistsRepresentRoom(@Param("buildingId") Long buildingId, @Param("memberId") Long memberId);
 
 	@Query(
 	  """

--- a/src/main/java/com/core/back9/service/BuildingService.java
+++ b/src/main/java/com/core/back9/service/BuildingService.java
@@ -39,8 +39,22 @@ public class BuildingService {
 	}
 
 	@Transactional(readOnly = true)
+	public Page<BuildingDTO.Info> selectAll(MemberDTO.Info member, Pageable pageable) {
+
+		return buildingRepository.findAllBuildingWithRoomsByBuildingIdAndMemberId(member.getId(), pageable)
+		  .map(building -> buildingMapper.toInfo(building, pageable));
+
+	}
+
+	@Transactional(readOnly = true)
 	public BuildingDTO.Info selectOne(Long buildingId, Pageable pageable) {
 		Building validBuilding = buildingRepository.getValidBuildingWithIdOrThrow(buildingId, Status.REGISTER);
+		return buildingMapper.toInfo(validBuilding, pageable);
+	}
+
+	@Transactional(readOnly = true)
+	public BuildingDTO.Info selectOne(MemberDTO.Info member, Long buildingId, Pageable pageable) {
+		Building validBuilding = buildingRepository.findValidBuildingWithRoomsByBuildingIdAndMemberId(buildingId, member.getId());
 		return buildingMapper.toInfo(validBuilding, pageable);
 	}
 


### PR DESCRIPTION
## 📝작업 내용
> 관리자/소유자 전용 빌딩, 호실 컨트롤러 분리
> 입주자 관련 부분은 제외
> 빌딩 조회 시 로그인 한 소유자 목록만 노출
> 대표호실 등록 오류 수정 (체크 아이디에 소유자를 넣어야하는데 관리자를 넣었...)

## #️⃣연관된 이슈
> closed : #95

## 💬리뷰 요구사항(선택)
