### PR TITLE
호실 상세페이지 데이터 가공

### DIFF
--- a/src/main/java/com/core/back9/controller/OwnerScoreController.java
+++ b/src/main/java/com/core/back9/controller/OwnerScoreController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -46,6 +48,15 @@ public class OwnerScoreController {
 		return ResponseEntity.ok(response);
 	}
 
+	@GetMapping("/monthly")
+	public ResponseEntity<List<ScoreDTO.DetailByMonth>> searchScoresByMonth(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId,
+	  @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
+	) {
+		return ResponseEntity.ok(scoreService.selectScoresByMonth(member, buildingId, roomId, yearMonth));
+	}
 
 	@PatchMapping("/{scoreId}/bookmark-add")
 	public ResponseEntity<ScoreDTO.Info> addBookmark(

--- a/src/main/java/com/core/back9/dto/ScoreDTO.java
+++ b/src/main/java/com/core/back9/dto/ScoreDTO.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 
 public class ScoreDTO {
 
@@ -53,6 +54,19 @@ public class ScoreDTO {
 		private RatingType ratingType;
 		private LocalDateTime createdAt;
 		private LocalDateTime updatedAt;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class DetailByMonth {    // 선택한 월을 기준으로 이전 1년치 데이터 배열로 주기
+		private YearMonth selectedMonth;    // 선택한 월(년/월)
+		private float totalAvg;                // 내 호실 점수
+		private float evaluationProgress;    // 평가 진행률
+		private float facilityAvg;        // 평가 항목별 점수 (시설)
+		private float managementAvg;    // 평가 항목별 점수 (관리)
+		private float complaintAvg;        // 평가 항목별 점수 (민원)
 	}
 
 }

--- a/src/main/java/com/core/back9/util/EvaluationSpecifications.java
+++ b/src/main/java/com/core/back9/util/EvaluationSpecifications.java
@@ -51,5 +51,12 @@ public class EvaluationSpecifications {
 		  criteriaBuilder.like(score.get("comment"), "%" + keyword + "%");
 	}
 
+	public static Specification<Score> isOneYearAgo(LocalDateTime baseDateTime) {
+		return (Root<Score> score, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) -> {
+			LocalDateTime oneYearAgo = baseDateTime.minusYears(1);
+			return criteriaBuilder.between(score.get("createdAt"), oneYearAgo, baseDateTime);
+		};
+	}
+
 
 }


### PR DESCRIPTION
## 📝작업 내용
> 현재 년월(yyyy-MM) 기준의 데이터 DTO, API 추가 구현
> 포함하는 데이터 (선택한 년/월, 월 기준-호실 평균 점수, 평가 항목별 점수)
> 선택한 년/월 기준으로 이전 1년의 데이터 12개 배열로 반환

## #️⃣연관된 이슈
> closed : #99

## 💬리뷰 요구사항(선택)
```
// 배열 첫번째 값은 선택한 년/월
[
  {
    "selected_month": "2024-06",
    "total_avg": 88,
    "evaluation_progress": 100,
    "facility_avg": 88,
    "management_avg": 0,
    "complaint_avg": 0
  },
  {
    "selected_month": "2024-05",
    "total_avg": 99,
    "evaluation_progress": 50,
    "facility_avg": 0,
    "management_avg": 99,
    "complaint_avg": 0
  },
  {
    "selected_month": "2024-04",
    "total_avg": 0,
    "evaluation_progress": 0,
    "facility_avg": 0,
    "management_avg": 0,
    "complaint_avg": 0
  },
...
....
.....
]
```