### PR TITLE
내호실 및 비교 호실 보증금/임대료 조회 로직 구현

### DIFF
--- a/src/main/java/com/core/back9/batch/tasklet/ContractInProgressTasklet.java
+++ b/src/main/java/com/core/back9/batch/tasklet/ContractInProgressTasklet.java
@@ -25,7 +25,7 @@ public class ContractInProgressTasklet implements Tasklet {
         log.info("========== Start Change Contract Status ==========");
         log.info("--- 실행 일자 : {} ---", time);
         // 이행 조건이 충족된 경우 이행 상태로 업데이트
-        int result = contractRepository.updateContractComplete(time);
+        int result = contractRepository.updateContractInProgress(time);
 
         if (result == 0) {
             log.info("========== 변경할 완료 상태인 계약 내용이 없습니다. ==========");

--- a/src/main/java/com/core/back9/controller/ContractController.java
+++ b/src/main/java/com/core/back9/controller/ContractController.java
@@ -38,6 +38,18 @@ public class ContractController { // TODO: Tenant, Member 구현 정도에 따�
 
     }
 
+    @GetMapping("/statistic") // TODO : 기간 조건 추가
+    public ResponseEntity<ContractDTO.StatisticInfo> getContractStatisticInfo(
+            @AuthMember MemberDTO.Info member,
+            @PathVariable(name = "buildingId") Long buildingId,
+            @PathVariable(name = "roomId") Long roomId
+    ) {
+
+        ContractDTO.CostInfo statisticInfo = contractService.getContractCostInfo(member, buildingId, roomId); // 내 호실 임대료 & 공실이 아닌 호실의 임대 평균값 반환
+
+        return null; // TODO : 내 호실의 임대료, 공실률, 재계약률 및 타호실 동일 항목 평균값 조회 결과 반환(StatisticInfo로 한번에 반환할 예정)
+    }
+
     @PostMapping("/{contractId}/tenants/{tenantId}")
     public ResponseEntity<ContractDTO.Info> renewContract(
             @AuthMember MemberDTO.Info member,

--- a/src/main/java/com/core/back9/dto/ContractDTO.java
+++ b/src/main/java/com/core/back9/dto/ContractDTO.java
@@ -108,4 +108,44 @@ public class ContractDTO {
 		private Long count;
 		private List<Info> infoList;
 	}
+
+//	@AllArgsConstructor
+//	@NoArgsConstructor
+//	@Builder
+//	@Getter
+	public static class StatisticInfo {
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class CostInfo {
+		private Long deposit;
+		private Long rentalPrice;
+		private double averageDeposit;
+		private double averageRentalPrice;
+
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class CostDto {
+		private Long id;
+		private Long deposit;
+		private Long rentalPrice;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class CostAverageDto {
+		private double averageDeposit;
+		private double averageRentalPrice;
+
+	}
+
 }

--- a/src/main/java/com/core/back9/mapper/ContractMapper.java
+++ b/src/main/java/com/core/back9/mapper/ContractMapper.java
@@ -40,4 +40,9 @@ public interface ContractMapper {
 
     ContractDTO.StatusInfo toStatusInfo(Contract contract);
 
+    ContractDTO.CostDto toCostDto(Long id, Long deposit, Long rentalPrice);
+
+    ContractDTO.CostAverageDto toCostAverageDto(Double averageDeposit, Double averageRentalPrice);
+
+    ContractDTO.CostInfo toCostInfo(ContractDTO.CostDto costDto, ContractDTO.CostAverageDto costAverageDto);
 }

--- a/src/main/java/com/core/back9/repository/ContractRepository.java
+++ b/src/main/java/com/core/back9/repository/ContractRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -101,4 +102,25 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
             and c.endDate=?1
             """)
     int updateContractInProgress(LocalDate now);
+
+    /* 이행 상태인 계약 중 가장 최신 계약 반환 */
+    @Query("""
+            select c
+            from Contract c
+            where c.room.id=?1
+            and c.contractStatus='IN_PROGRESS'
+            and c.status='REGISTER'
+            order by c.id desc
+            """)
+    Contract findByLatestContract(Long roomId);
+
+    @Query("""
+        select c
+        from Contract c
+        where c.room.building.id = ?1
+        and c.contractStatus = 'IN_PROGRESS'
+        and c.status = 'REGISTER'
+        AND (?2 IS NULL OR c.id <> ?2)
+        """)
+    List<Contract> findByContractInProgressPerBuilding(Long buildingId, Long contractId);
 }

--- a/src/test/java/com/core/back9/mapper/ContractMapperTest.java
+++ b/src/test/java/com/core/back9/mapper/ContractMapperTest.java
@@ -284,6 +284,28 @@ public class ContractMapperTest {
 
     }
 
+    @Test
+    @DisplayName("costDto와 costAverageDto를 costInfo로 매핑할 수 있다.")
+    void toCostInfo() {
+        // given
+        ContractDTO.CostDto costDto = ContractDTO.CostDto.builder()
+                .id(1L)
+                .deposit(10000000L)
+                .rentalPrice(200000L)
+                .build();
+        ContractDTO.CostAverageDto costAverageDto = ContractDTO.CostAverageDto.builder()
+                .averageRentalPrice(10000000)
+                .averageDeposit(200000)
+                .build();
+
+        // when
+        ContractDTO.CostInfo costInfo = contractMapper.toCostInfo(costDto, costAverageDto);
+
+        // then
+        assertThat(costInfo.getDeposit()).isEqualTo(10000000L);
+
+    }
+
     private Contract assumeContract(
             LocalDate startDate,
             LocalDate endDate,

--- a/src/test/java/com/core/back9/repository/ContractRepositoryTest.java
+++ b/src/test/java/com/core/back9/repository/ContractRepositoryTest.java
@@ -491,6 +491,177 @@ Contract contract2 = assumeContract(
 
     }
 
+    @Test
+    @DisplayName("이행 상태인 계약 중 가장 최신의 계약을 반환한다.")
+    void findByLatestContract() {
+        // given
+        Contract contract1 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract savedContract1 = contractRepository.save(contract1);
+        savedContract1.contractComplete();
+        savedContract1.contractInProgress();
+        savedContract1.contractExpire();
+
+        Contract contract2 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract savedContract2 = contractRepository.save(contract2);
+        savedContract2.contractComplete();
+        savedContract2.contractInProgress();
+        savedContract2.contractExpire();
+
+        Contract contract3 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract savedContract3 = contractRepository.save(contract3);
+        savedContract3.contractComplete();
+        savedContract3.contractInProgress();
+
+        // when
+        Contract latestContract = contractRepository.findByLatestContract(1L);
+
+        // then
+        assertThat(latestContract.getId()).isEqualTo(3L);
+
+    }
+
+    @Test
+    @DisplayName("이행 상태인 계약이 없을 시 null을 반환한다.")
+    void findByLatestContractNull() {
+        // given
+        Contract contract1 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract savedContract1 = contractRepository.save(contract1);
+        savedContract1.contractComplete();
+        savedContract1.contractInProgress();
+        savedContract1.contractExpire();
+
+        Contract contract2 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract savedContract2 = contractRepository.save(contract2);
+        savedContract2.contractComplete();
+        savedContract2.contractInProgress();
+        savedContract2.contractExpire();
+
+        Contract contract3 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract savedContract3 = contractRepository.save(contract3);
+        savedContract3.contractComplete();
+        savedContract3.contractInProgress();
+        savedContract3.contractExpire();
+
+        // when
+        Contract latestContract = contractRepository.findByLatestContract(1L);
+
+        // then
+        assertThat(latestContract).isNull();
+
+    }
+
+    @Test
+    @DisplayName("선택한 빌딩의 모든 진행 중인 비교 호실(타 호실)의 계약을 조회할 수 있다.")
+    void findByContractInProgressPerBuilding() {
+        // given
+        Contract contract1 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room1,
+                tenant1
+        );
+
+        Contract contract2 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room2,
+                tenant2
+        );
+
+        Contract contract3 = assumeContract(
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(20),
+                100000000L,
+                200000L,
+                ContractType.INITIAL,
+                room3,
+                tenant3
+        );
+
+        contractRepository.saveAll(List.of(contract1, contract2, contract3));
+        contract1.contractComplete();
+        contract1.contractInProgress();
+
+        contract2.contractComplete();
+        contract2.contractInProgress();
+
+        contract3.contractComplete();
+        contract3.contractInProgress();
+
+        // when
+        List<Contract> contractInProgressPerBuilding = contractRepository.findByContractInProgressPerBuilding(1L, contract1.getId());
+
+        // then
+        assertThat(contractInProgressPerBuilding)
+                .extracting("deposit", "rentalPrice", "contractStatus")
+                .contains(
+                        tuple(100000000L, 200000L, ContractStatus.IN_PROGRESS),
+                        tuple(100000000L, 200000L, ContractStatus.IN_PROGRESS),
+                        tuple(100000000L, 200000L, ContractStatus.IN_PROGRESS)
+                );
+
+    }
+
     private Contract assumeContract(
             LocalDate startDate,
             LocalDate endDate,


### PR DESCRIPTION
## 📝작업 내용
> 내호실 및 비교 호실 보증금/임대료 조회 로직 구현
> 보증금/임대료를 담는 DTO & Mapper 작성
> 로직 핵심기능 검증을 위한 케이스별 repository & service Test 작성

## #️⃣연관된 이슈
> closed : #100

## 💬리뷰 요구사항(선택)

> 임대료, 공실률, 재계약률 조회 로직이 생각보다 매우 길어질 것을 고려해 나누어 올립니다.
> 호실별 상태가 IN_PROGRESS 즉 계약 이행 중인 호실을 대상으로만 보증금/임대료를 뽑아 데이터를 가공하는 로직을 작성했습니다. 다른 상태는 실질적인 입실 상태가 아니라고 판단했기 때문입니다.
> 실제 조회시 잘못된 데이터가 프론트로 넘어가는 것을 방지해 서비스 레이어 테스트까지 마친 후 작업을 끝냈습니다.
> 현재 계약중인 내 호실이 없음을 고려해 null인 경우에도 null값을 사용해 조회할 수 있도록 쿼리문을 만들었음
> null을 허용하는 것이 맞는 선택인지는 모르겠으나 최대한 많은 케이스를 한번에 고려했습니다.
