### PR TITLE
내 호실 및 선택된 빌딩의 타 호실 평균 재계약률 조회 로직 구성

### DIFF
--- a/src/main/java/com/core/back9/controller/ContractController.java
+++ b/src/main/java/com/core/back9/controller/ContractController.java
@@ -45,7 +45,9 @@ public class ContractController { // TODO: Tenant, Member 구현 정도에 따�
             @PathVariable(name = "roomId") Long roomId
     ) {
 
-        ContractDTO.CostInfo statisticInfo = contractService.getContractCostInfo(member, buildingId, roomId); // 내 호실 임대료 & 공실이 아닌 호실의 임대 평균값 반환
+        ContractDTO.CostInfo costInfo = contractService.getContractCostInfo(member, buildingId, roomId); // 내 호실 임대료 & 공실이 아닌 호실의 임대 평균값 반환
+        ContractDTO.RenewalContractRateInfo renewalContractRateInfo = contractService.getRenewalContractRateInfo(member, buildingId, roomId);
+        ContractDTO.VacancyRateInfo vacancyRateInfo = contractService.getContractVacancyRate(member, buildingId, roomId);
 
         return null; // TODO : 내 호실의 임대료, 공실률, 재계약률 및 타호실 동일 항목 평균값 조회 결과 반환(StatisticInfo로 한번에 반환할 예정)
     }

--- a/src/main/java/com/core/back9/dto/ContractDTO.java
+++ b/src/main/java/com/core/back9/dto/ContractDTO.java
@@ -148,4 +148,22 @@ public class ContractDTO {
 
 	}
 
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class RenewalContractRateInfo {
+		private double renewalContractRate;
+		private double averageRenewalContractRate;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class VacancyRateInfo {
+		private double vacancyRate; // 내 호실 공실률
+		private double averageVacancyRate; // 비교 공실률
+	}
+
 }

--- a/src/main/java/com/core/back9/mapper/ContractMapper.java
+++ b/src/main/java/com/core/back9/mapper/ContractMapper.java
@@ -45,4 +45,6 @@ public interface ContractMapper {
     ContractDTO.CostAverageDto toCostAverageDto(Double averageDeposit, Double averageRentalPrice);
 
     ContractDTO.CostInfo toCostInfo(ContractDTO.CostDto costDto, ContractDTO.CostAverageDto costAverageDto);
+
+    ContractDTO.RenewalContractRateInfo toRenewalContractRateInfo(Double renewalContractRate, Double averageRenewalContractRate);
 }

--- a/src/main/java/com/core/back9/service/ContractService.java
+++ b/src/main/java/com/core/back9/service/ContractService.java
@@ -383,16 +383,13 @@ public class ContractService {
 
     private double calculateRenewalContract(List<Contract> contracts, Map<ContractType, Long> contractsTypeMap) {
         long initialContractsCount = contractsTypeMap.getOrDefault(ContractType.INITIAL, 0L);
-        long renewalContractsCount = contractsTypeMap.getOrDefault(ContractType.RENEWAL, 0L) + initialContractsCount - 1L; // 재계약 시도를 나타내는 계약 수
+        long renewalContractsCount = contractsTypeMap.getOrDefault(ContractType.RENEWAL, 0L);
+        long failedRenewalContractsCount = getRenewalContractFailedCount(contracts); // 재계약 실패를 나타내는 결과값
 
-        System.out.println(renewalContractsCount);
+        long attemptedRenewalContractsCount = initialContractsCount + renewalContractsCount - 1L; // 재계약 시도를 나타내는 결과값
+        long pureRenewalContractsCount = attemptedRenewalContractsCount - failedRenewalContractsCount; // 재계약을 성공한 경우를 나타내는 결과값
 
-        long failedRenewalContractsCount = getRenewalContractFailedCount(contracts);
-
-        long pureRenewalContractsCount = renewalContractsCount - failedRenewalContractsCount;
-        long totalContractsCount = initialContractsCount + pureRenewalContractsCount;
-
-        System.out.println(totalContractsCount);
+        long totalContractsCount = initialContractsCount + pureRenewalContractsCount; // 실제 총 계약 수
 
         double result = ((double) pureRenewalContractsCount / (totalContractsCount - 1)) * 100;
 

--- a/src/main/java/com/core/back9/service/ContractService.java
+++ b/src/main/java/com/core/back9/service/ContractService.java
@@ -386,7 +386,7 @@ public class ContractService {
         long renewalContractsCount = contractsTypeMap.getOrDefault(ContractType.RENEWAL, 0L);
         long failedRenewalContractsCount = getRenewalContractFailedCount(contracts); // 재계약 실패를 나타내는 결과값
 
-        long attemptedRenewalContractsCount = initialContractsCount + renewalContractsCount - 1L; // 재계약 시도를 나타내는 결과값
+        long attemptedRenewalContractsCount = failedRenewalContractsCount + renewalContractsCount; // 재계약 시도를 나타내는 결과값
         long pureRenewalContractsCount = attemptedRenewalContractsCount - failedRenewalContractsCount; // 재계약을 성공한 경우를 나타내는 결과값
 
         long totalContractsCount = initialContractsCount + pureRenewalContractsCount; // 실제 총 계약 수

--- a/src/main/java/com/core/back9/service/ContractService.java
+++ b/src/main/java/com/core/back9/service/ContractService.java
@@ -385,10 +385,14 @@ public class ContractService {
         long initialContractsCount = contractsTypeMap.getOrDefault(ContractType.INITIAL, 0L);
         long renewalContractsCount = contractsTypeMap.getOrDefault(ContractType.RENEWAL, 0L) + initialContractsCount - 1L; // 재계약 시도를 나타내는 계약 수
 
+        System.out.println(renewalContractsCount);
+
         long failedRenewalContractsCount = getRenewalContractFailedCount(contracts);
 
-        long pureRenewalContractsCount = renewalContractsCount -= failedRenewalContractsCount;
-        long totalContractsCount = initialContractsCount + renewalContractsCount;
+        long pureRenewalContractsCount = renewalContractsCount - failedRenewalContractsCount;
+        long totalContractsCount = initialContractsCount + pureRenewalContractsCount;
+
+        System.out.println(totalContractsCount);
 
         double result = ((double) pureRenewalContractsCount / (totalContractsCount - 1)) * 100;
 

--- a/src/test/java/com/core/back9/service/ContractServiceTest.java
+++ b/src/test/java/com/core/back9/service/ContractServiceTest.java
@@ -840,7 +840,6 @@ public class ContractServiceTest extends ContractServiceFixture {
                 })
                 .collect(Collectors.toList());
 
-
         // when
         ContractDTO.RenewalContractRateInfo renewalContractRateInfo = contractService.getRenewalContractRateInfo(member, 1L, room1.getId());
 
@@ -850,7 +849,262 @@ public class ContractServiceTest extends ContractServiceFixture {
 
     }
 
+    @Test
+    @DisplayName("비교 호실 추정 재계약률 평균값 일치 테스트.")
+    void getRenewalContractRateInfo50Percent() {
+        // given
+        MemberDTO.Info member = MemberDTO.Info.builder()
+                .id(2L)
+                .role(Role.OWNER)
+                .build();
 
+        List<Contract> contracts1 = IntStream.range(0, 1)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            ContractType.INITIAL,
+                            room1,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts1_1 = IntStream.range(0, 1)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            ContractType.INITIAL,
+                            room1,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts1_2 = IntStream.range(0, 1)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            ContractType.INITIAL,
+                            room1,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        /* ========== 아래 부터 비교 호실 데이터 구성 ========== */
+        List<Contract> contracts2 = IntStream.range(0, 2)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room2,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 2 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts2_1 = IntStream.range(0, 2)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room2,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 2 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts2_2 = IntStream.range(0, 2)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room2,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 2 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts3 = IntStream.range(0, 2)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room3,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 2 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts3_1 = IntStream.range(0, 2)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room3,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 2 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        // when
+        ContractDTO.RenewalContractRateInfo renewalContractRateInfo = contractService.getRenewalContractRateInfo(member, 1L, room1.getId());
+
+        // then
+        assertThat(renewalContractRateInfo.getRenewalContractRate()).isEqualTo(0.0);
+        assertThat(renewalContractRateInfo.getAverageRenewalContractRate()).isEqualTo(63.35);
+
+    }
 
     private Contract assumeContract(
             LocalDate startDate,

--- a/src/test/java/com/core/back9/service/ContractServiceTest.java
+++ b/src/test/java/com/core/back9/service/ContractServiceTest.java
@@ -683,7 +683,7 @@ public class ContractServiceTest extends ContractServiceFixture {
     }
 
     @Test
-    @DisplayName("내 호실의 재계약률과 비교 호실의 재계약률 평균 데이터를 조회할 수 있다.")
+    @DisplayName("내 호실의 재계약이 없을 경우 결과는 0.0이다.")
     void getRenewalContractRateInfo() {
         // given
         MemberDTO.Info member = MemberDTO.Info.builder()
@@ -691,24 +691,23 @@ public class ContractServiceTest extends ContractServiceFixture {
                 .role(Role.OWNER)
                 .build();
 
-        List<Contract> contracts1 = IntStream.range(0, 2)
+        List<Contract> contracts1 = IntStream.range(0, 1)
                 .mapToObj(i -> {
                     long startDate = 10L * i + 1;
                     long endDate = 10L * (i + 1);
-                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
 
                     Contract contract = assumeContract(
                             LocalDate.now().plusDays(startDate),
                             LocalDate.now().plusDays(endDate),
                             100000000L,
                             200000L,
-                            contractType,
+                            ContractType.INITIAL,
                             room1,
                             tenant1
                     );
                     Contract savedContract = contractRepository.save(contract);
 
-                    if (i < 10 - 1) {
+                    if (i < 1) {
                         savedContract.contractComplete();
                         savedContract.contractInProgress();
                         savedContract.contractExpire();
@@ -721,7 +720,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                 })
                 .collect(Collectors.toList());
 
-        List<Contract> contracts1_1 = IntStream.range(0, 2)
+        List<Contract> contracts1_1 = IntStream.range(0, 1)
                 .mapToObj(i -> {
                     long startDate = 10L * i + 1;
                     long endDate = 10L * (i + 1);
@@ -732,13 +731,13 @@ public class ContractServiceTest extends ContractServiceFixture {
                             LocalDate.now().plusDays(endDate),
                             100000000L,
                             200000L,
-                            contractType,
+                            ContractType.INITIAL,
                             room1,
                             tenant1
                     );
                     Contract savedContract = contractRepository.save(contract);
 
-                    if (i < 2 - 1) {
+                    if (i < 1) {
                         savedContract.contractComplete();
                         savedContract.contractInProgress();
                         savedContract.contractExpire();
@@ -751,24 +750,23 @@ public class ContractServiceTest extends ContractServiceFixture {
                 })
                 .collect(Collectors.toList());
 
-        List<Contract> contracts1_2 = IntStream.range(0, 2)
+        List<Contract> contracts1_2 = IntStream.range(0, 1)
                 .mapToObj(i -> {
                     long startDate = 10L * i + 1;
                     long endDate = 10L * (i + 1);
-                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
 
                     Contract contract = assumeContract(
                             LocalDate.now().plusDays(startDate),
                             LocalDate.now().plusDays(endDate),
                             100000000L,
                             200000L,
-                            contractType,
+                            ContractType.INITIAL,
                             room1,
                             tenant1
                     );
                     Contract savedContract = contractRepository.save(contract);
 
-                    if (i < 2 - 1) {
+                    if (i < 1) {
                         savedContract.contractComplete();
                         savedContract.contractInProgress();
                         savedContract.contractExpire();
@@ -782,7 +780,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                 .collect(Collectors.toList());
 
         /* ========== 아래 부터 비교 호실 데이터 구성 ========== */
-        List<Contract> contracts2 = IntStream.range(0, 10)
+        List<Contract> contracts2 = IntStream.range(0, 3)
                 .mapToObj(i -> {
                     long startDate = 10L * i + 1;
                     long endDate = 10L * (i + 1);
@@ -799,7 +797,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                     );
                     Contract savedContract = contractRepository.save(contract);
 
-                    if (i < 10 - 1) {
+                    if (i < 3 - 1) {
                         savedContract.contractComplete();
                         savedContract.contractInProgress();
                         savedContract.contractExpire();
@@ -812,7 +810,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                 })
                 .collect(Collectors.toList());
 
-        List<Contract> contracts3 = IntStream.range(0, 10)
+        List<Contract> contracts3 = IntStream.range(0, 3)
                 .mapToObj(i -> {
                     long startDate = 10L * i + 1;
                     long endDate = 10L * (i + 1);
@@ -829,7 +827,7 @@ public class ContractServiceTest extends ContractServiceFixture {
                     );
                     Contract savedContract = contractRepository.save(contract);
 
-                    if (i < 10 - 1) {
+                    if (i < 3 - 1) {
                         savedContract.contractComplete();
                         savedContract.contractInProgress();
                         savedContract.contractExpire();
@@ -847,10 +845,12 @@ public class ContractServiceTest extends ContractServiceFixture {
         ContractDTO.RenewalContractRateInfo renewalContractRateInfo = contractService.getRenewalContractRateInfo(member, 1L, room1.getId());
 
         // then
-        assertThat(renewalContractRateInfo.getRenewalContractRate()).isEqualTo(60.0);
+        assertThat(renewalContractRateInfo.getRenewalContractRate()).isEqualTo(0.0);
         assertThat(renewalContractRateInfo.getAverageRenewalContractRate()).isEqualTo(100.0);
 
     }
+
+
 
     private Contract assumeContract(
             LocalDate startDate,

--- a/src/test/java/com/core/back9/service/ContractServiceTest.java
+++ b/src/test/java/com/core/back9/service/ContractServiceTest.java
@@ -17,6 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -680,6 +682,175 @@ public class ContractServiceTest extends ContractServiceFixture {
 
     }
 
+    @Test
+    @DisplayName("내 호실의 재계약률과 비교 호실의 재계약률 평균 데이터를 조회할 수 있다.")
+    void getRenewalContractRateInfo() {
+        // given
+        MemberDTO.Info member = MemberDTO.Info.builder()
+                .id(2L)
+                .role(Role.OWNER)
+                .build();
+
+        List<Contract> contracts1 = IntStream.range(0, 2)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room1,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 10 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts1_1 = IntStream.range(0, 2)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room1,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 2 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts1_2 = IntStream.range(0, 2)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room1,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 2 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        /* ========== 아래 부터 비교 호실 데이터 구성 ========== */
+        List<Contract> contracts2 = IntStream.range(0, 10)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room2,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 10 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+        List<Contract> contracts3 = IntStream.range(0, 10)
+                .mapToObj(i -> {
+                    long startDate = 10L * i + 1;
+                    long endDate = 10L * (i + 1);
+                    ContractType contractType = (i == 0) ? ContractType.INITIAL : ContractType.RENEWAL;
+
+                    Contract contract = assumeContract(
+                            LocalDate.now().plusDays(startDate),
+                            LocalDate.now().plusDays(endDate),
+                            100000000L,
+                            200000L,
+                            contractType,
+                            room3,
+                            tenant1
+                    );
+                    Contract savedContract = contractRepository.save(contract);
+
+                    if (i < 10 - 1) {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                        savedContract.contractExpire();
+                    } else {
+                        savedContract.contractComplete();
+                        savedContract.contractInProgress();
+                    }
+
+                    return contract;
+                })
+                .collect(Collectors.toList());
+
+
+        // when
+        ContractDTO.RenewalContractRateInfo renewalContractRateInfo = contractService.getRenewalContractRateInfo(member, 1L, room1.getId());
+
+        // then
+        assertThat(renewalContractRateInfo.getRenewalContractRate()).isEqualTo(60.0);
+        assertThat(renewalContractRateInfo.getAverageRenewalContractRate()).isEqualTo(100.0);
+
+    }
 
     private Contract assumeContract(
             LocalDate startDate,


### PR DESCRIPTION
## 📝작업 내용
> 내 호실의 재계약률과 내 호실 이외 선택된 빌딩의 타 호실 평균 재계약률을 조회할 수 있는 로직 구성
> 기능 테스트 완료

> ContractServiceTest : line 687~843 (getRenewalContractRateInfo) 참고

## #️⃣연관된 이슈
> closed : #107

## 💬리뷰 요구사항(선택)
> 재계약률 공식에 대한 구체적인 가이드가 없어서 최대한 정확하다고 생각되는 방식으로 산출방식을 구현했습니다.

> initialContractsCount : 신계약을 카운팅한 결과값
> renewalContractsCount : 전체 재계약을 카운팅한 결과값
> attemptedRenewalContractsCount = initialContractsCount + renewalContractsCount  -1(최초계약 수는 카운팅 결과에서 제외, 첫 재계약 시점부터 카운팅하기 위함)
> failedRenewalContractsCount : 재계약 실패 케이스를 카운팅한 결과값
-> 최초계약에 해당하는 데이터를 기반으로 이전 데이터를 조회해 RENEWAL인 경우 RENEWAL -> INITIAL이므로 재계약 실패로 간주
> pureRenewalContractsCount : 재계약 시도 수에서 실패 재계약 수를 차감한 재계약 성공 횟수에 해당하는 결과값
> totalContractsCount = initialContractsCount + pureRenewalContractsCount : 실제 총 계약 수

재계약 결과 = initialContractsCount / pureRenewalContractsCount

```
double result = ((double) pureRenewalContractsCount / (totalContractsCount - 1)) * 100;
```
> 최근 계약이 INITIAL - 이전 계약이 RENEWAL 은 재계약 실패인 경우로 판단해 재계약 실패 횟수를 추가했습니다.
> 단순히 재계약 만을 한 횟수를 카운팅해 결과를 나타내는 것이 아닌 재계약을 못한 경우도 검증해야 한다고 판단했습니다.
> 코드 정리가 안된 부분은 나머지 로직 작성 후 정리해나갈 예정입니다.