### PR TITLE
대시보드 데이터 가공 추가 작업

### DIFF
--- a/src/main/java/com/core/back9/controller/BuildingController.java
+++ b/src/main/java/com/core/back9/controller/BuildingController.java
@@ -4,6 +4,7 @@ import com.core.back9.dto.BuildingDTO;
 import com.core.back9.dto.MemberDTO;
 import com.core.back9.security.AuthMember;
 import com.core.back9.service.BuildingService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -17,6 +18,7 @@ public class BuildingController {
 
 	private final BuildingService buildingService;
 
+	@Operation(summary = "빌딩 정보 등록", description = "빌딩 정보를 등록한다. (admin 계정만 가능)")
 	@PostMapping("")
 	public ResponseEntity<BuildingDTO.Response> register(
 	  @AuthMember MemberDTO.Info member,
@@ -26,6 +28,7 @@ public class BuildingController {
 		return ResponseEntity.ok(buildingService.create(member, request));
 	}
 
+	@Operation(summary = "빌딩 정보 수정", description = "빌딩 정보를 수정한다. (admin 계정만 가능)")
 	@PatchMapping("/{buildingId}")
 	public ResponseEntity<BuildingDTO.Info> modify(
 	  @AuthMember MemberDTO.Info member,
@@ -37,6 +40,7 @@ public class BuildingController {
 		return ResponseEntity.ok(buildingService.update(member, buildingId, request, pageable));
 	}
 
+	@Operation(summary = "빌딩 정보 삭제", description = "빌딩 정보를 삭제한다. (admin 계정만 가능)")
 	@DeleteMapping("/{buildingId}")
 	public ResponseEntity<Boolean> unregister(
 	  @AuthMember MemberDTO.Info member,

--- a/src/main/java/com/core/back9/controller/OwnerBuildingController.java
+++ b/src/main/java/com/core/back9/controller/OwnerBuildingController.java
@@ -6,11 +6,14 @@ import com.core.back9.dto.ScoreDTO;
 import com.core.back9.security.AuthMember;
 import com.core.back9.service.BuildingService;
 import com.core.back9.service.ScoreService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/buildings")
@@ -20,6 +23,8 @@ public class OwnerBuildingController {
 	private final BuildingService buildingService;
 	private final ScoreService scoreService;
 
+	@Operation(summary = "전체 빌딩 정보 조회",
+	  description = "로그인 한 소유자(owner)의 전체 빌딩 정보를 조회한다.")
 	@GetMapping("")
 	public ResponseEntity<Page<BuildingDTO.Info>> getAll(
 	  @AuthMember MemberDTO.Info member,
@@ -28,6 +33,8 @@ public class OwnerBuildingController {
 		return ResponseEntity.ok(buildingService.selectAll(member, pageable));
 	}
 
+	@Operation(summary = "단일 빌딩 정보 조회",
+	  description = "로그인 한 소유자(owner)의 단일 빌딩 정보를 조회한다.")
 	@GetMapping("/{buildingId}")
 	public ResponseEntity<BuildingDTO.Info> getOne(
 	  @AuthMember MemberDTO.Info member,
@@ -37,15 +44,38 @@ public class OwnerBuildingController {
 		return ResponseEntity.ok(buildingService.selectOne(member, buildingId, pageable));
 	}
 
-	@GetMapping("/{buildingId}/quarterly")
-	public ResponseEntity<ScoreDTO.DetailByQuarter> searchScoresByQuarter(
+	@Operation(summary = "대시보드 페이지",
+	  description = "해당 빌딩의 내 모든 호실의 현재분기의 총 평균 점수, 평가 타입별 평균 점수를 조회한다.")
+	@GetMapping("/{buildingId}/my-quarterly-score")
+	public ResponseEntity<ScoreDTO.AvgByQuarter> searchScoreByQuarter(
 	  @AuthMember MemberDTO.Info member,
 	  @PathVariable Long buildingId,
 	  @RequestParam int year,
-	  @RequestParam int quarter,
-	  Pageable pageable
+	  @RequestParam int quarter
 	) {
-		return ResponseEntity.ok(scoreService.selectScoresByQuarter(member, buildingId, year, quarter, pageable));
+		return ResponseEntity.ok(scoreService.selectScoresByQuarter(member, buildingId, year, quarter));
+	}
+
+	@Operation(summary = "대시보드 페이지",
+	  description = "해당 빌딩의 내 각 호실의 분기별 총 평균 점수를 조회한다.")
+	@GetMapping("/{buildingId}/my-rooms-quarterly-score")
+	public ResponseEntity<ScoreDTO.CurrentAndBeforeQuarterlyTotalAvg> searchQuarterlyScoreOfMyRooms(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @RequestParam int year,
+	  @RequestParam int quarter
+	) {
+		return ResponseEntity.ok(scoreService.selectQuarterlyScoreOfMyRooms(member, buildingId, year, quarter));
+	}
+
+	@Operation(summary = "대시보드 페이지",
+	  description = "해당 빌딩의 내 각 호실의 1년간의 총 평균 점수, 평가 타입별 평균 점수를 조회한다.")
+	@GetMapping("/{buildingId}/my-rooms-year-score")
+	public ResponseEntity<List<ScoreDTO.AllAvgByRoom>> searchYearScoresOfMyRooms(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId
+	) {
+		return ResponseEntity.ok(scoreService.selectYearScoreOfMyRooms(member, buildingId));
 	}
 
 }

--- a/src/main/java/com/core/back9/controller/OwnerRoomController.java
+++ b/src/main/java/com/core/back9/controller/OwnerRoomController.java
@@ -2,15 +2,21 @@ package com.core.back9.controller;
 
 import com.core.back9.dto.MemberDTO;
 import com.core.back9.dto.RoomDTO;
+import com.core.back9.dto.ScoreDTO;
 import com.core.back9.entity.constant.RatingType;
 import com.core.back9.security.AuthMember;
 import com.core.back9.service.RoomService;
 import com.core.back9.service.ScoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.YearMonth;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/buildings/{buildingId}/rooms")
@@ -20,7 +26,9 @@ public class OwnerRoomController {
 	private final RoomService roomService;
 	private final ScoreService scoreService;
 
-	@GetMapping("")    // 대시보드에서 호실 목록 보여줄 때
+	@Operation(summary = "전체 호실 조회",
+	  description = "해당 건물의 전체 호실의 기본정보와 계약목록, 설정상태를 조회한다.")
+	@GetMapping("")
 	public ResponseEntity<Page<RoomDTO.Info>> getAll(
 	  @AuthMember MemberDTO.Info member,
 	  @PathVariable Long buildingId,
@@ -29,6 +37,8 @@ public class OwnerRoomController {
 		return ResponseEntity.ok(roomService.selectAll(member, buildingId, pageable));
 	}
 
+	@Operation(summary = "단일 호실 조회",
+	  description = "해당 건물의 해당 호실의 기본정보와 계약목록, 설정상태를 조회한다.")
 	@GetMapping("/{roomId}")
 	public ResponseEntity<RoomDTO.Info> getOne(
 	  @AuthMember MemberDTO.Info member,
@@ -38,6 +48,8 @@ public class OwnerRoomController {
 		return ResponseEntity.ok(roomService.selectOne(member, buildingId, roomId));
 	}
 
+	@Operation(summary = "평가받기 설정 변경",
+	  description = "평가받기 설정을 켠다")
 	@PostMapping("/{roomId}/setting-on")
 	public ResponseEntity<RoomDTO.Info> turnOn(
 	  @AuthMember MemberDTO.Info member,
@@ -47,6 +59,8 @@ public class OwnerRoomController {
 		return ResponseEntity.ok(roomService.updateSwitch(member, buildingId, roomId, true));
 	}
 
+	@Operation(summary = "평가받기 설정 변경",
+	  description = "평가받기 설정을 끈다")
 	@PostMapping("/{roomId}/setting-off")
 	public ResponseEntity<RoomDTO.Info> turnOff(
 	  @AuthMember MemberDTO.Info member,
@@ -56,6 +70,7 @@ public class OwnerRoomController {
 		return ResponseEntity.ok(roomService.updateSwitch(member, buildingId, roomId, false));
 	}
 
+	@Operation(summary = "평가 독려 메시지 수정")
 	@PatchMapping("/{roomId}/modify-encourage-message")
 	public ResponseEntity<RoomDTO.Info> modify(
 	  @AuthMember MemberDTO.Info member,
@@ -66,6 +81,7 @@ public class OwnerRoomController {
 		return ResponseEntity.ok(roomService.updateEncourageMessage(member, buildingId, roomId, encourageMessage));
 	}
 
+	@Operation(summary = "대표 호실 설정")
 	@PatchMapping("/{roomId}/setting-represent")
 	public ResponseEntity<Page<RoomDTO.Info>> modifyRepresent(
 	  @AuthMember MemberDTO.Info member,
@@ -76,6 +92,8 @@ public class OwnerRoomController {
 		return ResponseEntity.ok(roomService.updateRepresent(member, buildingId, roomId, pageable));
 	}
 
+	@Operation(summary = "평가 레코드 발행",
+	  description = "해당 호실에 계약중인 입주사의 유효한 입주자에게 평가 레코드를 발생시킨다.")
 	@PatchMapping("/{roomId}/scores-generate")
 	public void evaluation(
 	  @AuthMember MemberDTO.Info member,
@@ -83,8 +101,20 @@ public class OwnerRoomController {
 	  @PathVariable Long roomId,
 	  @RequestParam RatingType ratingType
 	) {
-		// 빌딩-호실에 대해 현재 계약중인 입주사에 평가를 수동으로 발생
 		scoreService.create(member, buildingId, roomId, ratingType);
+	}
+
+	@Operation(summary = "호실 상세 페이지",
+	  description = "해당 호실과 타호실의 선택한 년/월로부터 이전 1년간 총 평균 점수, 평가 항목별 점수, 평가 진행률을 배열로 조회한다.")
+	@GetMapping("/{roomId}/yearly-score-interval-month")
+	public ResponseEntity<ScoreDTO.ListOfYearAvgWithMeAndOthers> searchYearScoresIntervalMonth(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long buildingId,
+	  @PathVariable Long roomId,
+	  @RequestParam @DateTimeFormat(pattern = "yyyy-MM")
+	  @Parameter(description = "선택 년-월", example = "2024-05") YearMonth yearMonth
+	) {
+		return ResponseEntity.ok(scoreService.selectYearScoresIntervalMonth(member, buildingId, roomId, yearMonth));
 	}
 
 }

--- a/src/main/java/com/core/back9/controller/OwnerScoreController.java
+++ b/src/main/java/com/core/back9/controller/OwnerScoreController.java
@@ -5,6 +5,7 @@ import com.core.back9.dto.ScoreDTO;
 import com.core.back9.entity.constant.RatingType;
 import com.core.back9.security.AuthMember;
 import com.core.back9.service.ScoreService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,8 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.YearMonth;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -24,6 +23,7 @@ public class OwnerScoreController {
 
 	private final ScoreService scoreService;
 
+	@Operation(summary = "평가 상세 보기 조회", description = "모든 조건에 부합하는 평가 항목을 조회한다.")
 	@GetMapping("")
 	public ResponseEntity<Page<ScoreDTO.Info>> searchScores(
 	  @AuthMember MemberDTO.Info member,
@@ -43,16 +43,7 @@ public class OwnerScoreController {
 		return ResponseEntity.ok(response);
 	}
 
-	@GetMapping("/monthly")
-	public ResponseEntity<List<ScoreDTO.DetailByMonth>> searchScoresByMonth(
-	  @AuthMember MemberDTO.Info member,
-	  @PathVariable Long buildingId,
-	  @PathVariable Long roomId,
-	  @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
-	) {
-		return ResponseEntity.ok(scoreService.selectScoresByMonth(member, buildingId, roomId, yearMonth));
-	}
-
+	@Operation(summary = "평가 북마크", description = "해당 평가를 북마크 설정한다.")
 	@PatchMapping("/{scoreId}/bookmark-add")
 	public ResponseEntity<ScoreDTO.Info> addBookmark(
 	  @AuthMember MemberDTO.Info member,
@@ -63,6 +54,7 @@ public class OwnerScoreController {
 		return ResponseEntity.ok(scoreService.updateBookmark(member, scoreId, true));
 	}
 
+	@Operation(summary = "평가 북마크", description = "해당 평가를 북마크 해제한다.")
 	@PatchMapping("/{scoreId}/bookmark-remove")
 	public ResponseEntity<ScoreDTO.Info> removeBookmark(
 	  @AuthMember MemberDTO.Info member,

--- a/src/main/java/com/core/back9/dto/ScoreDTO.java
+++ b/src/main/java/com/core/back9/dto/ScoreDTO.java
@@ -6,8 +6,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.util.List;
 
 public class ScoreDTO {
 
@@ -60,7 +62,19 @@ public class ScoreDTO {
 	@NoArgsConstructor
 	@Builder
 	@Getter
-	public static class DetailByMonth {    // 선택한 월을 기준으로 이전 1년치 데이터 배열로 주기
+	public static class ScoreSearchRequest {
+		private LocalDate startDate;
+		private LocalDate endDate;
+		private RatingType ratingType;
+		private Boolean bookmark;
+		private String keyword;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class AllAvgByMonth {    // 선택한 월을 기준으로 이전 1년치 데이터 배열로 주기
 		private YearMonth selectedMonth;    // 선택한 월(년/월)
 		private float totalAvg;                // 내 호실 점수
 		private float evaluationProgress;    // 평가 진행률
@@ -73,7 +87,45 @@ public class ScoreDTO {
 	@NoArgsConstructor
 	@Builder
 	@Getter
-	public static class DetailByQuarter {    // 선택한 월을 기준으로 이전 1년치 데이터 배열로 주기
+	public static class AllAvgByRoom {
+		private Long roomId;
+		private String roomName;
+		private List<AllAvgByMonth> allAvgByMonthList;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class TotalAvgByRoom {
+		private Long roomId;
+		private String roomName;
+		private float totalAvg;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class CurrentAndBeforeQuarterlyTotalAvg {
+		private List<TotalAvgByRoom> current;
+		private List<TotalAvgByRoom> before;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class ListOfYearAvgWithMeAndOthers {
+		private List<AllAvgByMonth> my;
+		private List<AllAvgByMonth> others;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class AvgByQuarter {    // 선택한 월을 기준으로 이전 1년치 데이터 배열로 주기
 		private int selectedYear;
 		private int selectedQuarter;
 		private float totalAvg;                // 내 호실 점수

--- a/src/main/java/com/core/back9/mapper/ScoreMapper.java
+++ b/src/main/java/com/core/back9/mapper/ScoreMapper.java
@@ -1,10 +1,13 @@
 package com.core.back9.mapper;
 
 import com.core.back9.dto.ScoreDTO;
+import com.core.back9.entity.Room;
 import com.core.back9.entity.Score;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingConstants;
-import org.mapstruct.ReportingPolicy;
+import com.core.back9.entity.constant.RatingType;
+import org.mapstruct.*;
+
+import java.time.YearMonth;
+import java.util.List;
 
 @Mapper(
   componentModel = MappingConstants.ComponentModel.SPRING,
@@ -18,5 +21,60 @@ public interface ScoreMapper {
 	ScoreDTO.UpdateResponse toUpdateResponse(Score score);
 
 	ScoreDTO.Info toInfo(Score score);
+
+	@Mapping(source = "year", target = "selectedYear")
+	@Mapping(source = "quarter", target = "selectedQuarter")
+	@Mapping(target = "totalAvg", expression = "java(calculateTotalAvg(scores))")
+	@Mapping(target = "facilityAvg", expression = "java(calculateScoreTypeAvg(scores, com.core.back9.entity.constant.RatingType.FACILITY))")
+	@Mapping(target = "managementAvg", expression = "java(calculateScoreTypeAvg(scores, com.core.back9.entity.constant.RatingType.MANAGEMENT))")
+	@Mapping(target = "complaintAvg", expression = "java(calculateScoreTypeAvg(scores, com.core.back9.entity.constant.RatingType.COMPLAINT))")
+	ScoreDTO.AvgByQuarter toQuarterlyTotalAvg(int year, int quarter, List<Score> scores);
+
+	@Mapping(source = "room.id", target = "roomId")
+	@Mapping(source = "room.name", target = "roomName")
+	@Mapping(target = "totalAvg", expression = "java(calculateTotalAvg(scores))")
+	ScoreDTO.TotalAvgByRoom toTotalAvgByRoom(Room room, List<Score> scores);
+
+	ScoreDTO.CurrentAndBeforeQuarterlyTotalAvg toQuarterlyTotalAvgWithCurrentAndBefore(
+	  List<ScoreDTO.TotalAvgByRoom> current, List<ScoreDTO.TotalAvgByRoom> before
+	);
+
+	@Mapping(source = "current", target = "selectedMonth")
+	@Mapping(target = "totalAvg", expression = "java(calculateTotalAvg(scores))")
+	@Mapping(target = "evaluationProgress", expression = "java(calculateEvaluationProgress(scores))")
+	@Mapping(target = "facilityAvg", expression = "java(calculateScoreTypeAvg(scores, com.core.back9.entity.constant.RatingType.FACILITY))")
+	@Mapping(target = "managementAvg", expression = "java(calculateScoreTypeAvg(scores, com.core.back9.entity.constant.RatingType.MANAGEMENT))")
+	@Mapping(target = "complaintAvg", expression = "java(calculateScoreTypeAvg(scores, com.core.back9.entity.constant.RatingType.COMPLAINT))")
+	ScoreDTO.AllAvgByMonth toAllAvgWithMonth(YearMonth current, List<Score> scores);
+
+	@Mapping(source = "room.id", target = "roomId")
+	@Mapping(source = "room.name", target = "roomName")
+	ScoreDTO.AllAvgByRoom toAllAvgWithMonthByRoom(Room room, List<ScoreDTO.AllAvgByMonth> allAvgByMonthList);
+
+	ScoreDTO.ListOfYearAvgWithMeAndOthers toListOfYearAvgWithMeAndOthers(
+	  List<ScoreDTO.AllAvgByMonth> my, List<ScoreDTO.AllAvgByMonth> others
+	);
+
+	@Named("calculateTotalAvg")
+	default float calculateTotalAvg(List<Score> scores) {
+		return (float) scores.stream()
+		  .filter(score -> !score.getCreatedAt().isEqual(score.getUpdatedAt()))
+		  .mapToInt(Score::getScore).average().orElse(0);
+	}
+
+	@Named("calculateEvaluationProgress")
+	default float calculateEvaluationProgress(List<Score> scores) {
+		float completed = scores.stream().filter(score -> !score.getCreatedAt().equals(score.getUpdatedAt())).count();
+		return completed > 0 ? completed / scores.size() * 100 : 0;
+	}
+
+	@Named("calculateScoreTypeAvg")
+	default float calculateScoreTypeAvg(List<Score> scores, RatingType ratingType) {
+		return (float) scores.stream()
+		  .filter(score -> score.getRatingType() == ratingType)
+		  .mapToInt(Score::getScore)
+		  .average()
+		  .orElse(0);
+	}
 
 }

--- a/src/main/java/com/core/back9/util/EvaluationSpecifications.java
+++ b/src/main/java/com/core/back9/util/EvaluationSpecifications.java
@@ -56,13 +56,13 @@ public class EvaluationSpecifications {
 		};
 	}
 
-	public static Specification<Score> hasRoomList(List<Room> rooms) {
+	public static Specification<Score> hasRoomList(List<Room> rooms, boolean has) {
 		return ((root, query, criteriaBuilder) -> {
 			if (rooms == null || rooms.isEmpty()) {
 				return criteriaBuilder.conjunction();
 			}
 			Join<Score, Room> roomJoin = root.join("room", JoinType.INNER);
-			return roomJoin.in(rooms);
+			return has ? roomJoin.in(rooms) : criteriaBuilder.not(roomJoin.in(rooms));
 		});
 	}
 


### PR DESCRIPTION
## 📝작업 내용
> 대시보드 - 내 모든 호실의 현재/이전 분기별 총 평균 점수
> 대시보드 - 내 모든 호실의 1년간 총 평균 점수 (현재로부터 이전 1년 고정)
> 스코어 관련 DTO builder -> Mapper 작업
> 소유자 관련 컨트롤러 스웨거 주석 추가

## #️⃣연관된 이슈
> closed : #106

## 💬리뷰 요구사항(선택)
> 필요한 데이터는 전부 정리했습니다.
> 뭔 데이터가 한페이지에 기준도 다르고 맥락도 달라서 중복 요청이 꽤 나옵니다.
