### PR TITLE
비교 호실의 재계약률을 평균하는 과정에서 소수점 둘째자리까지 출력되는 이슈 해결

### DIFF
--- a/src/main/java/com/core/back9/service/ContractService.java
+++ b/src/main/java/com/core/back9/service/ContractService.java
@@ -375,13 +375,12 @@ public class ContractService {
         List<Contract> contracts = contractRepository.findByAllContractAllRoomsPerBuilding(buildingId, room.getId(), statusList);
         Map<Room, Map<ContractType, Long>> contractCountsPerRoomAndType = getContractCountsPerRoomAndType(contracts);
 
-        return contractCountsPerRoomAndType.values().stream()
+        double avgData = contractCountsPerRoomAndType.values().stream()
                 .mapToDouble(contractsTypeMap -> calculateRenewalContract(contracts, contractsTypeMap))
                 .average()
-                .stream()
-                .map(avg -> Math.round(avg * 10.0) / 10.0)
-                .findAny()
                 .orElse(0.0);
+
+        return Math.round(avgData * 10.0) / 10.0;
     }
 
     private double calculateRenewalContract(List<Contract> contracts, Map<ContractType, Long> contractsTypeMap) {

--- a/src/main/java/com/core/back9/service/ContractService.java
+++ b/src/main/java/com/core/back9/service/ContractService.java
@@ -378,6 +378,9 @@ public class ContractService {
         return contractCountsPerRoomAndType.values().stream()
                 .mapToDouble(contractsTypeMap -> calculateRenewalContract(contracts, contractsTypeMap))
                 .average()
+                .stream()
+                .map(avg -> Math.round(avg * 10.0) / 10.0)
+                .findAny()
                 .orElse(0.0);
     }
 

--- a/src/test/java/com/core/back9/service/ContractServiceTest.java
+++ b/src/test/java/com/core/back9/service/ContractServiceTest.java
@@ -1102,7 +1102,7 @@ public class ContractServiceTest extends ContractServiceFixture {
 
         // then
         assertThat(renewalContractRateInfo.getRenewalContractRate()).isEqualTo(0.0);
-        assertThat(renewalContractRateInfo.getAverageRenewalContractRate()).isEqualTo(63.35);
+        assertThat(renewalContractRateInfo.getAverageRenewalContractRate()).isEqualTo(63.4);
 
     }
 


### PR DESCRIPTION
## 📝작업 내용
> 비교 호실의 재계약률을 평균하는 과정에서 소수점 둘째자리까지 출력되는 이슈 해결

## #️⃣연관된 이슈
> closed : #108

## 💬리뷰 요구사항(선택)
![image](https://github.com/KPT-Final-Team9/back9/assets/140988037/0f2e8d05-2a12-4105-9317-063e2f6fcc34)
손으로 계산 했을 때 63.4가 나와야했지만 63.35가 반환됨

```java
private double getRenewalRelativeContractData(Long buildingId, Room room, List<ContractStatus> statusList) {

///....
return contractCountsPerRoomAndType.values().stream()
                .mapToDouble(contractsTypeMap -> calculateRenewalContract(contracts, contractsTypeMap))
                .average()
                .orElse(0.0);
}
```

각 호실별 재계약률 산출 값을 받아 평균하는 과정에서 추가적인 소수점 처리가 필요하다는 것을 알게 되었음

```java
return contractCountsPerRoomAndType.values().stream()
                .mapToDouble(contractsTypeMap -> calculateRenewalContract(contracts, contractsTypeMap))
                .average()
                .stream()
                .map(avg -> Math.round(avg * 10.0) / 10.0) // 추가 소수점 처리
                .findAny()
                .orElse(0.0);

------

double avgData = contractCountsPerRoomAndType.values().stream()
                .mapToDouble(contractsTypeMap -> calculateRenewalContract(contracts, contractsTypeMap))
                .average()
                .orElse(0.0);

        return Math.round(avgData * 10.0) / 10.0;
```
위 해결 방안 중 선택해 해결하는 방식을 채택

![image](https://github.com/KPT-Final-Team9/back9/assets/140988037/eb548ee5-bcd8-482d-9492-b6493986710d)



