### PR TITLE
대시보드에서 보여줄 점수가 없는 경우를 판단하는 API 추가

### DIFF
--- a/src/main/java/com/core/back9/controller/OwnerBuildingController.java
+++ b/src/main/java/com/core/back9/controller/OwnerBuildingController.java
@@ -78,4 +78,10 @@ public class OwnerBuildingController {
 		return ResponseEntity.ok(scoreService.selectYearScoreOfMyRooms(member, buildingId));
 	}
 
+	@Operation(summary = "대시보드 페이지", description = "해당 빌딩의 내 모든 호실에 대해 최근 2년 동안 유효한 평가가 1건도 없으면 false를 반환한다.")
+	@GetMapping("/{buildingId}/valid-score")
+	public ResponseEntity<Boolean> hasValidScore(@AuthMember MemberDTO.Info member, @PathVariable Long buildingId) {
+		return ResponseEntity.ok(scoreService.hasValidScore(member, buildingId));
+	}
+
 }

--- a/src/main/java/com/core/back9/repository/RoomRepository.java
+++ b/src/main/java/com/core/back9/repository/RoomRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -68,5 +69,7 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 		return findFirstRepresentRoom(buildingId, memberId)
 		  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_ROOM));
 	}
+
+	List<Room> findAllByBuildingIdAndMemberIdAndStatus(Long buildingId, Long MemberId, Status status);
 
 }

--- a/src/main/java/com/core/back9/repository/ScoreRepository.java
+++ b/src/main/java/com/core/back9/repository/ScoreRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -59,5 +61,15 @@ public interface ScoreRepository extends JpaRepository<Score, Long>, JpaSpecific
 	  @Param("memberId") Long memberId,
 	  @Param("roomId") Long roomId
 	);
+
+	@Query("""
+          select s
+          from Score s
+          where s.room.id = :roomId
+          and s.status = :status
+          and s.createdAt != s.updatedAt
+          and s.updatedAt > :twoYearsAgo
+          """)
+	List<Score> findFirstByRoomIdAndStatus(Long roomId, Status status, LocalDateTime twoYearsAgo);
 
 }

--- a/src/main/java/com/core/back9/service/ScoreService.java
+++ b/src/main/java/com/core/back9/service/ScoreService.java
@@ -1,5 +1,6 @@
 package com.core.back9.service;
 
+import com.core.back9.common.entity.BaseEntity;
 import com.core.back9.dto.MemberDTO;
 import com.core.back9.dto.ScoreDTO;
 import com.core.back9.entity.Building;
@@ -299,6 +300,22 @@ public class ScoreService {
 			allAvgByMonthList.add(scoreMapper.toAllAvgWithMonth(current, scoresOfMonth));
 		}
 		return allAvgByMonthList;
+	}
+
+	public boolean hasValidScore(MemberDTO.Info member, Long buildingId) {
+
+		List<Long> roomIds = roomRepository.findAllByBuildingIdAndMemberIdAndStatus(buildingId, member.getId(), Status.REGISTER).stream()
+				.map(BaseEntity::getId).toList();
+
+        LocalDateTime twoYearsAgo = LocalDateTime.now().minusYears(2);
+
+		for (Long roomId : roomIds) {
+            if (!scoreRepository.findFirstByRoomIdAndStatus(roomId, Status.REGISTER, twoYearsAgo).isEmpty()) {
+                return true;
+            }
+		}
+
+		return false;
 	}
 
 }


### PR DESCRIPTION
…환하는 API 구현

## 📝작업 내용
> 건물을 기준으로 내가 소유한 모든 호실에 대해 최근 2년 동안 평가가 1건도 없는 경우 false를 반환하는 API 구현

## #️⃣연관된 이슈
> closed : #123

## 💬리뷰 요구사항(선택)
> 대시보드 페이지의 해당 섹션에서 제일 먼저 호출될 API라서 다음 스텝과 연결해서 사용하면 더 효율적일 것 같다는 생각에 고민을 많이 했습니다. 그렇게 하면 다른 쪽도 수정을 많이 해야 할 것 같아서 조회해서 2년 내에 평가가 1건이라도 잡히면 true를 반환하게 만들었습니다.
