### PR TITLE
평가 완료 상태를 확인하기 위한 평가 조회 API 추가

### DIFF
--- a/src/main/java/com/core/back9/controller/UserScoreController.java
+++ b/src/main/java/com/core/back9/controller/UserScoreController.java
@@ -4,9 +4,12 @@ import com.core.back9.dto.MemberDTO;
 import com.core.back9.dto.ScoreDTO;
 import com.core.back9.security.AuthMember;
 import com.core.back9.service.ScoreService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -15,6 +18,7 @@ public class UserScoreController {
 
 	private final ScoreService scoreService;
 
+	@Operation(summary = "생성된 평가 진행", description = "입주자가 이용하고 있는 호실에 대한 평가를 진행한다.")
 	@PatchMapping("/{scoreId}")
 	public ResponseEntity<ScoreDTO.UpdateResponse> updateEvaluation(
 	  @AuthMember MemberDTO.Info member,
@@ -22,6 +26,14 @@ public class UserScoreController {
 	  @RequestBody ScoreDTO.UpdateRequest updateRequest
 	) {
 		return ResponseEntity.ok(scoreService.updateScore(member, scoreId, updateRequest));
+	}
+
+	@Operation(summary = "진행 중인 평가 정보 조회", description = "진행 중인 평가 정보를 조회해 평가 완료 여부를 확인한다.")
+	@GetMapping("/in-progress")
+	public ResponseEntity<List<ScoreDTO.Info>> getEvaluationsInProgress(
+			@AuthMember MemberDTO.Info member
+	) {
+		return ResponseEntity.ok(scoreService.getEvaluationsInProgress(member));
 	}
 
 }

--- a/src/main/java/com/core/back9/dto/ScoreDTO.java
+++ b/src/main/java/com/core/back9/dto/ScoreDTO.java
@@ -50,6 +50,7 @@ public class ScoreDTO {
 	@Builder
 	@Getter
 	public static class Info {
+		private Long id;
 		private int score;
 		private String comment;
 		private boolean bookmark;

--- a/src/main/java/com/core/back9/repository/ScoreRepository.java
+++ b/src/main/java/com/core/back9/repository/ScoreRepository.java
@@ -1,6 +1,7 @@
 package com.core.back9.repository;
 
 import com.core.back9.entity.Score;
+import com.core.back9.entity.constant.RatingType;
 import com.core.back9.entity.constant.Status;
 import com.core.back9.exception.ApiErrorCode;
 import com.core.back9.exception.ApiException;
@@ -70,6 +71,8 @@ public interface ScoreRepository extends JpaRepository<Score, Long>, JpaSpecific
           and s.createdAt != s.updatedAt
           and s.updatedAt > :twoYearsAgo
           """)
-	List<Score> findFirstByRoomIdAndStatus(Long roomId, Status status, LocalDateTime twoYearsAgo);
+	List<Score> findByRoomIdAndStatus(Long roomId, Status status, LocalDateTime twoYearsAgo);
+
+	Optional<Score> findFirstByMemberIdAndRatingTypeAndStatusOrderByIdDesc(Long memberId, RatingType ratingType, Status status);
 
 }

--- a/src/main/java/com/core/back9/service/ScoreService.java
+++ b/src/main/java/com/core/back9/service/ScoreService.java
@@ -310,12 +310,29 @@ public class ScoreService {
         LocalDateTime twoYearsAgo = LocalDateTime.now().minusYears(2);
 
 		for (Long roomId : roomIds) {
-            if (!scoreRepository.findFirstByRoomIdAndStatus(roomId, Status.REGISTER, twoYearsAgo).isEmpty()) {
+            if (!scoreRepository.findByRoomIdAndStatus(roomId, Status.REGISTER, twoYearsAgo).isEmpty()) {
                 return true;
             }
 		}
 
 		return false;
+	}
+
+	public List<ScoreDTO.Info> getEvaluationsInProgress(MemberDTO.Info member) {
+		List<Score> evaluationsInProgress = new ArrayList<>();
+		Long memberId = member.getId();
+
+		addEvaluation(evaluationsInProgress, memberId, RatingType.FACILITY);
+		addEvaluation(evaluationsInProgress, memberId, RatingType.MANAGEMENT);
+		addEvaluation(evaluationsInProgress, memberId, RatingType.COMPLAINT);
+
+		return evaluationsInProgress.stream().map(scoreMapper::toInfo).toList();
+	}
+
+	private void addEvaluation(List<Score> evaluationsInProgress, Long memberId, RatingType ratingType) {
+		scoreRepository.findFirstByMemberIdAndRatingTypeAndStatusOrderByIdDesc(memberId, ratingType, Status.REGISTER)
+				.ifPresent(evaluationsInProgress::add);
+
 	}
 
 }


### PR DESCRIPTION
## 📝작업 내용
> 평가 완료 상태를 확인하기 위한 평가 조회 API 추가

## #️⃣연관된 이슈
> closed : #133

## 💬리뷰 요구사항(선택)
> 가장 최근에 생성된(지금 평가가 가능한) 평가에 대한 정보를 조회할 수 있도록 구현했습니다. 민원 평가에 대해서는 따로 처리하지 않고 시설, 관리 평가와 동일하게 만들었고 지금은 민원 평가 레코드 자체가 없기 때문에 이 API에서 반환하는 평가 목록은 최대 2개인 상태입니다.
> 지금 입주사가 여러 호실에 대해 동시에 계약을 할 수 있는 상태고, 입주자는 호실이나 계약에 대해 모르고 입주사만 알고 있는 상태라 모든 호실에 대한 평가 레코드가 모든 입주자에게 다 생성돼서 한 입주사가 한 호실에 대해서만 계약을 할 수 있게 수정해야 할 것 같습니다.