### PR TITLE
마지막 계약 기간이 1년이 넘는 계약이고 현재 진행중일 시 공실률이 -단위까지 조회되는 현상 개선

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -65,7 +65,7 @@ if [ "$CURRENT_SERVER_PORT" = "8082" -o -z "$IS_DEV1" ];then # dev2운영중 or 
 
 #  CURRENT_SERVER_PORT=$(docker exec nginx grep -o 'proxy_pass http://[^:]\+:[0-9]\+' /etc/nginx/nginx.conf | awk -F ':' '{print $NF}' | head -n1)
   CURRENT_SERVER_PORT=$(curl -s http://172.18.0.1:8081/public-api/health | grep -o '"status":"[^"]*' | awk -F '"' '{print $4}')
-  if [ "$HEALTH_CHECK_REQUEST_DEV1" = "Connected" ];then
+  if [ "$CURRENT_SERVER_PORT" = "Connected" ];then
     echo "dev1 서버가 성공적으로 배포되었습니다! [ CURRENT_SERVER_PORT ] : $CURRENT_SERVER_PORT"
     /home/ubuntu/app/alarm.sh
   fi
@@ -109,7 +109,7 @@ else # dev2 운영중인 경우
 
 #  CURRENT_SERVER_PORT=$(docker exec nginx grep -o 'proxy_pass http://[^:]\+:[0-9]\+' /etc/nginx/nginx.conf | awk -F ':' '{print $NF}' | head -n1)
   CURRENT_SERVER_PORT=$(curl -s http://172.18.0.1:8082/public-api/health | grep -o '"status":"[^"]*' | awk -F '"' '{print $4}')
-  if [ "$HEALTH_CHECK_REQUEST_DEV2" = "Connected" ];then
+  if [ "$CURRENT_SERVER_PORT" = "Connected" ];then
     echo "dev2 서버가 성공적으로 배포되었습니다! [ CURRENT_SERVER_PORT ] : $CURRENT_SERVER_PORT"
     /home/ubuntu/app/alarm.sh
   fi

--- a/src/main/java/com/core/back9/controller/ContractController.java
+++ b/src/main/java/com/core/back9/controller/ContractController.java
@@ -50,7 +50,7 @@ public class ContractController {
             @PathVariable(name = "roomId") Long roomId
     ) {
 
-        LocalDate startDate = LocalDate.now().minusYears(1); // 검색 범위를 1년으로 설정하기 위한 변수
+        LocalDate startDate = LocalDate.now().minusYears(1).plusDays(1); // 검색 범위를 1년으로 설정하기 위한 변수
 
         ContractDTO.CostInfo costInfo = contractService.getContractCostInfo(member, buildingId, roomId); // 내 호실 임대료 & 공실이 아닌 호실의 임대 평균값 반환
         ContractDTO.RenewalContractRateInfo renewalContractRateInfo = contractService.getRenewalContractRateInfo(member, buildingId, roomId);

--- a/src/main/java/com/core/back9/repository/RoomRepository.java
+++ b/src/main/java/com/core/back9/repository/RoomRepository.java
@@ -45,10 +45,10 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
 	@Query(
 	  """
-		SELECT COUNT(r) = 0 
-		FROM Room r 
-		WHERE r.building.id = :buildingId 
-		AND r.member.id = :memberId 
+		SELECT COUNT(r) = 0
+		FROM Room r
+		WHERE r.building.id = :buildingId
+		AND r.member.id = :memberId
 		AND r.represent = true
 		"""
 	)

--- a/src/main/java/com/core/back9/service/ContractService.java
+++ b/src/main/java/com/core/back9/service/ContractService.java
@@ -558,10 +558,16 @@ public class ContractService {
             if (lastContract.getContractStatus() == ContractStatus.IN_PROGRESS) {
                 additionalOccupancy += ChronoUnit.DAYS.between(lastContract.getStartDate(), lastDate);
             } else {
-                additionalOccupancy += ChronoUnit.DAYS.between(lastContract.getStartDate(), lastContract.getCheckOut());
+                if(lastContract.getStartDate().isBefore(lastDate.minusYears(1).plusDays(1)) && 365 <= ChronoUnit.DAYS.between(lastContract.getStartDate(), lastContract.getCheckOut())) {
+                    additionalOccupancy += ChronoUnit.DAYS.between(lastDate.minusYears(1).plusDays(1), lastContract.getCheckOut());
+                } else {
+                    additionalOccupancy += ChronoUnit.DAYS.between(lastContract.getStartDate(), lastContract.getCheckOut());
+                }
             }
         }
-        return additionalOccupancy;
+
+        return Math.min(additionalOccupancy, 365L);
+
     }
 
     private long getOccupancy(List<Contract> contracts, LocalDate startDate) {


### PR DESCRIPTION
만료된 계약의 기간이 1년이 넘는 계약일 시 공실률이 -단위까지 조회되는 현상 개선

- 진행중인 1년 넘는 기간이 반환될 시 365를 반환 (-> 공실률 : 0)
- 종료된 1년 넘는 계약이 체크될 시 기간 범위 시작일~종료된 계약의 만료일 까지를 바탕으로 결과 산출

## 📝작업 내용
> 종료된 1년 넘는 계약이 체크될 시 기간 범위 시작일~종료된 계약의 만료일 까지를 바탕으로 결과 산출
> 진행중인 1년 넘는 기간이 반환될 시 365를 반환 (-> 공실률 : 0)
> 배포 스크립트 수정(현재 포트번호 체크 및 버전 전환 시 중단점 삭제)
## #️⃣연관된 이슈
> closed : #142 

## 💬리뷰 요구사항(선택)

