### PR TITLE
Swagger Server별 url 수동 설정( local/dev )

### DIFF
--- a/src/main/java/com/core/back9/common/config/SwaggerConfig.java
+++ b/src/main/java/com/core/back9/common/config/SwaggerConfig.java
@@ -51,8 +51,6 @@ public class SwaggerConfig {
                 .in(SecurityScheme.In.HEADER) // 헤더에 위치
                 .name("Authorization"); // 이름은 Authorization
 
-        Server server = new Server();
-        server.setUrl("https://officeback.site");
 
         List<Tag> tagList = List.of(
                 new Tag().name("member-public-controller").description("<b>[공통]</b> 회원가입 & 로그인 API"),
@@ -71,7 +69,10 @@ public class SwaggerConfig {
                 .addList("Bearer Token");
         return new OpenAPI()
                 .tags(tagList)
-                .servers(List.of(server))
+                .servers(List.of(
+                        new Server().url("https://officeback.site").description("개발 서버용"),
+                        new Server().url("http://localhost:8080").description("로컬 서버용")
+                ))
                 .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
                 .addSecurityItem(securityRequirement);
     }


### PR DESCRIPTION
## 📝작업 내용
> Swagger Server별 url 수동 설정

## #️⃣연관된 이슈
> closed : #150

## 💬리뷰 요구사항(선택)
![image](https://github.com/KPT-Final-Team9/back9/assets/140988037/9eb77151-e8da-4aa5-b7ff-3d2809a12287)

> https 환경에서는 server url을 수동 설정해줘야 swagger에도 적용이 되는데 이로 인해 local환경에서 올바른 url이 매핑되지 않는 이슈가 발생했습니다. 이로 인해 local url도 직접 지정해주었습니다. 

> local 환경에서는 로컬 서버용 url을 선택해서 사용해주시면 됩니다. 