### PR TITLE
민원 관련 기능 구현

### DIFF
--- a/src/main/java/com/core/back9/controller/AppUserComplaintController.java
+++ b/src/main/java/com/core/back9/controller/AppUserComplaintController.java
@@ -1,0 +1,66 @@
+package com.core.back9.controller;
+
+import com.core.back9.dto.ComplaintDTO;
+import com.core.back9.dto.MemberDTO;
+import com.core.back9.security.AuthMember;
+import com.core.back9.service.ComplaintService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/app/complaints")
+@RestController
+public class AppUserComplaintController {
+
+	private final ComplaintService complaintService;
+
+	@PostMapping("")
+	public ResponseEntity<Void> register(
+	  @AuthMember MemberDTO.Info member,
+	  @RequestBody ComplaintDTO.RegisterRequest registerRequest
+	) {
+		complaintService.create(member, registerRequest);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("")
+	public ResponseEntity<List<ComplaintDTO.Info>> getAll(
+	  @AuthMember MemberDTO.Info member
+	) {
+		return ResponseEntity.ok(complaintService.selectAllByMemberId(member));
+	}
+
+	@PatchMapping("/{complaintId}/completed")
+	public ResponseEntity<Void> modifyCompleted(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long complaintId,
+	  @RequestBody(required = false) String completeMessage
+	) {
+		complaintService.updateCompleted(member, complaintId, completeMessage);
+		return ResponseEntity.noContent().build();
+	}
+
+	@PatchMapping("/{complaintId}/rejected")
+	public ResponseEntity<Void> modifyRejected(
+	  @AuthMember MemberDTO.Info member,
+	  @PathVariable Long complaintId,
+	  @RequestBody(required = false) String rejectMessage
+	) {
+		complaintService.updateRejected(member, complaintId, rejectMessage);
+		return ResponseEntity.noContent().build();
+	}
+
+
+	@DeleteMapping("/{complaintId}")
+	public ResponseEntity<Void> unregister(
+	  @AuthMember MemberDTO.Info user,
+	  @PathVariable Long complaintId
+	) {
+		complaintService.delete(user, complaintId);
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/src/main/java/com/core/back9/dto/ComplaintDTO.java
+++ b/src/main/java/com/core/back9/dto/ComplaintDTO.java
@@ -1,0 +1,44 @@
+package com.core.back9.dto;
+
+import com.core.back9.entity.constant.ComplaintStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ComplaintDTO {
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class RegisterRequest {
+		private Long roomId;
+		private String complaintMessage;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class CompletedRequest {
+		private ComplaintStatus complaintStatus;
+		private String completedMessage;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	@Getter
+	public static class Info {
+		private Long id;
+		private String complaintMessage;
+		private ComplaintStatus complaintStatus;
+		private String completedMessage;
+		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
+	}
+
+}

--- a/src/main/java/com/core/back9/dto/MemberDTO.java
+++ b/src/main/java/com/core/back9/dto/MemberDTO.java
@@ -89,6 +89,14 @@ public class MemberDTO {
         private TenantDTO.Info tenant;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
+
+        public boolean isUser() {
+            return this.role == Role.USER;
+        }
+
+        public boolean isOwner() {
+            return this.role == Role.OWNER;
+        }
     }
 
     @AllArgsConstructor

--- a/src/main/java/com/core/back9/entity/Complaint.java
+++ b/src/main/java/com/core/back9/entity/Complaint.java
@@ -1,0 +1,95 @@
+package com.core.back9.entity;
+
+import com.core.back9.common.entity.BaseEntity;
+import com.core.back9.dto.MemberDTO;
+import com.core.back9.entity.constant.ComplaintStatus;
+import com.core.back9.entity.constant.Status;
+import com.core.back9.exception.ApiErrorCode;
+import com.core.back9.exception.ApiException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "complaints")
+public class Complaint extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "room_id", nullable = false, updatable = false)
+	private Room room;
+
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+	@JoinColumn(name = "member_id", nullable = false, updatable = false)
+	private Member member;
+
+	@Column(name = "complaint_message", nullable = false)
+	private String complaintMessage;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false)
+	private Status status = Status.REGISTER;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "complaint_status", nullable = false)
+	private ComplaintStatus complaintStatus = ComplaintStatus.IN_PROGRESS;
+
+	@Column(name = "completed_message")
+	private String completedMessage;
+
+	@Builder
+	public Complaint(Room room, Member member,
+					 String complaintMessage, Status status,
+					 ComplaintStatus complaintStatus, String completedMessage
+	) {
+		this.room = room;
+		this.member = member;
+		this.complaintMessage = complaintMessage;
+		this.status = status;
+		this.complaintStatus = complaintStatus;
+		this.completedMessage = completedMessage;
+	}
+
+	public Complaint updateComplaintStatus(ComplaintStatus complaintStatus) {
+		this.complaintStatus = complaintStatus;
+		return this;
+	}
+
+	public Complaint completeComplaint(MemberDTO.Info member, String completeMessage) {
+		if (member.isOwner()) {
+			this.complaintStatus = ComplaintStatus.COMPLETED;
+			if (completeMessage == null || completeMessage.isEmpty()) {
+				this.completedMessage = "요청하신 민원이 처리 완료됐습니다.";
+			} else {
+				this.completedMessage = completeMessage;
+			}
+			return this;
+		}
+		throw new ApiException(ApiErrorCode.DO_NOT_HAVE_PERMISSION);
+	}
+
+	public Complaint rejectComplaint(MemberDTO.Info member, String rejectMessage) {
+		if (member.isOwner()) {
+			this.complaintStatus = ComplaintStatus.REJECTED;
+			if (rejectMessage == null || rejectMessage.isEmpty()) {
+				this.completedMessage = "요청하신 민원이 반려되었습니다.";
+			} else {
+				this.completedMessage = rejectMessage;
+			}
+			return this;
+		}
+		throw new ApiException(ApiErrorCode.DO_NOT_HAVE_PERMISSION);
+	}
+
+	public void delete() {
+		this.status = Status.UNREGISTER;
+	}
+
+	public boolean isPossibleToDelete(MemberDTO.Info user) {
+		return this.member.getId().equals(user.getId()) && complaintStatus == ComplaintStatus.PENDING;
+	}
+
+}

--- a/src/main/java/com/core/back9/entity/constant/ComplaintStatus.java
+++ b/src/main/java/com/core/back9/entity/constant/ComplaintStatus.java
@@ -1,0 +1,16 @@
+package com.core.back9.entity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ComplaintStatus {
+	PENDING("접수 대기"),
+	RECEIVED("접수 완료"),
+	IN_PROGRESS("처리 진행중"),
+	COMPLETED("처리 완료"),
+	REJECTED("반려");
+
+	private final String label;
+}

--- a/src/main/java/com/core/back9/exception/ApiErrorCode.java
+++ b/src/main/java/com/core/back9/exception/ApiErrorCode.java
@@ -15,6 +15,7 @@ public enum ApiErrorCode {
     NOT_FOUND_VALID_MEMBER(HttpStatus.NOT_FOUND.value(), "유효한 사용자를 찾을 수 없습니다."),
     NOT_FOUND_VALID_PRINCIPAL(HttpStatus.NOT_FOUND.value(), "유효한 주체를 찾을 수 없습니다."),
     NOT_FOUND_VALID_EVALUATION(HttpStatus.NOT_FOUND.value(), "유효한 평가를 찾을 수 없습니다."),
+    NOT_FOUND_VALID_COMPLAINT(HttpStatus.NOT_FOUND.value(), "유효한 민원을 찾을 수 없습니다."),
 
     ROOM_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST.value(), "이미 계약된 호실이 존재합니다."),
     CONTRACT_NOT_IN_PROGRESS(HttpStatus.BAD_REQUEST.value(), "계약이 이행 중인 상태가 아닙니다."),

--- a/src/main/java/com/core/back9/mapper/ComplaintMapper.java
+++ b/src/main/java/com/core/back9/mapper/ComplaintMapper.java
@@ -1,0 +1,18 @@
+package com.core.back9.mapper;
+
+import com.core.back9.dto.ComplaintDTO;
+import com.core.back9.entity.Complaint;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+  componentModel = MappingConstants.ComponentModel.SPRING,
+  unmappedSourcePolicy = ReportingPolicy.IGNORE,
+  unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface ComplaintMapper {
+
+	ComplaintDTO.Info toInfo(Complaint complaint);
+
+}

--- a/src/main/java/com/core/back9/repository/ComplaintRepository.java
+++ b/src/main/java/com/core/back9/repository/ComplaintRepository.java
@@ -1,0 +1,43 @@
+package com.core.back9.repository;
+
+import com.core.back9.entity.Complaint;
+import com.core.back9.entity.constant.Status;
+import com.core.back9.exception.ApiErrorCode;
+import com.core.back9.exception.ApiException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
+
+	@Query("SELECT c FROM Complaint c WHERE c.id = :complaintId AND c.status = 'REGISTER'")
+	Optional<Complaint> findFirstById(Long complaintId);
+
+	default Complaint getValidComplaint(Long complaintId) {
+		return findFirstById(complaintId)
+		  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_COMPLAINT));
+	}
+
+	/* 소유자가 자신의 특정 호실에 등록된 민원 조회 */
+	List<Complaint> findAllByRoomIdAndStatus(Long roomId, Status status);
+
+	/* 소유자가 모든 호실에 등록된 민원 조회 */
+	@Query(
+	  """
+		SELECT DISTINCT c FROM Complaint c\s
+				JOIN FETCH c.room r
+				JOIN FETCH r.building b
+				WHERE r.member.id = :ownerId
+		"""
+	)
+	List<Complaint> findAllComplaintsByOwnerId(@Param("ownerId") Long ownerId);
+
+	/* 입주자가 자신이 등록한 모든 민원 목록 조회 */
+	List<Complaint> findAllByMemberId(Long memberId);
+
+}

--- a/src/main/java/com/core/back9/repository/RoomRepository.java
+++ b/src/main/java/com/core/back9/repository/RoomRepository.java
@@ -72,4 +72,11 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
 	List<Room> findAllByBuildingIdAndMemberIdAndStatus(Long buildingId, Long MemberId, Status status);
 
+	Optional<Room> findFirstByIdAndStatus(Long roomId, Status status);
+
+	default Room getValidRoomByIdAndStatus(Long roomId, Status status) {
+		return findFirstByIdAndStatus(roomId, status)
+		  .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_VALID_ROOM));
+	}
+
 }

--- a/src/main/java/com/core/back9/service/ComplaintService.java
+++ b/src/main/java/com/core/back9/service/ComplaintService.java
@@ -1,0 +1,72 @@
+package com.core.back9.service;
+
+import com.core.back9.dto.ComplaintDTO;
+import com.core.back9.dto.MemberDTO;
+import com.core.back9.entity.Complaint;
+import com.core.back9.entity.Member;
+import com.core.back9.entity.Room;
+import com.core.back9.entity.constant.ComplaintStatus;
+import com.core.back9.entity.constant.Status;
+import com.core.back9.mapper.ComplaintMapper;
+import com.core.back9.repository.ComplaintRepository;
+import com.core.back9.repository.MemberRepository;
+import com.core.back9.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ComplaintService {
+
+	private final MemberRepository memberRepository;
+	private final RoomRepository roomRepository;
+	private final ComplaintRepository complaintRepository;
+	private final ComplaintMapper complaintMapper;
+
+	public void create(MemberDTO.Info member, ComplaintDTO.RegisterRequest registerRequest) {
+		Member validMember =
+		  memberRepository.getValidMemberWithIdAndRole(member.getId(), member.getRole(), Status.REGISTER);
+		Room validRoom =
+		  roomRepository.getValidRoomByIdAndStatus(registerRequest.getRoomId(), Status.REGISTER);
+
+		Complaint newComplaint = Complaint.builder()
+		  .room(validRoom)
+		  .member(validMember)
+		  .complaintMessage(registerRequest.getComplaintMessage())
+		  .status(Status.REGISTER)
+		  .complaintStatus(ComplaintStatus.IN_PROGRESS)
+		  .build();
+		complaintRepository.save(newComplaint);
+	}
+
+	public List<ComplaintDTO.Info> selectAllByMemberId(MemberDTO.Info member) {
+		if (member.isUser()) {
+			return complaintRepository.findAllByMemberId(member.getId())
+			  .stream().map(complaintMapper::toInfo).toList();
+		}
+		return complaintRepository.findAllComplaintsByOwnerId(member.getId())
+		  .stream().map(complaintMapper::toInfo).toList();
+	}
+
+	public void updateCompleted(MemberDTO.Info member, Long complaintId, String completeMessage) {
+		Complaint validComplaint = complaintRepository.getValidComplaint(complaintId);
+		validComplaint.completeComplaint(member, completeMessage);
+	}
+
+	public void updateRejected(MemberDTO.Info member, Long complaintId, String rejectMessage) {
+		Complaint validComplaint = complaintRepository.getValidComplaint(complaintId);
+		validComplaint.rejectComplaint(member, rejectMessage);
+	}
+
+	public void delete(MemberDTO.Info user, Long complaintId) {
+		Complaint validComplaint = complaintRepository.getValidComplaint(complaintId);
+		if (validComplaint.isPossibleToDelete(user)) {
+			validComplaint.delete();
+		}
+	}
+
+}

--- a/src/main/resources/db/migration/common/V12__complaint-create.sql
+++ b/src/main/resources/db/migration/common/V12__complaint-create.sql
@@ -1,0 +1,19 @@
+CREATE TABLE complaints
+(
+    id                BIGINT AUTO_INCREMENT NOT NULL,
+    created_at        timestamp NULL,
+    updated_at        timestamp NULL,
+    room_id           BIGINT NULL,
+    member_id         BIGINT NULL,
+    complaint_message VARCHAR(255) NOT NULL,
+    status            VARCHAR(255) NULL,
+    complaint_status  VARCHAR(255) NULL,
+    completed_message VARCHAR(255) NULL,
+    CONSTRAINT pk_complaints PRIMARY KEY (id)
+);
+
+ALTER TABLE complaints
+    ADD CONSTRAINT FK_COMPLAINTS_ON_MEMBER FOREIGN KEY (member_id) REFERENCES members (id);
+
+ALTER TABLE complaints
+    ADD CONSTRAINT FK_COMPLAINTS_ON_ROOM FOREIGN KEY (room_id) REFERENCES rooms (id);


### PR DESCRIPTION
## 📝작업 내용
> 민원 테이블 생성
> 입주자 : 민원 생성, 조회, 삭제(접수대기 상태) 가능
> 소유자 : 민원 조회, 수정(처리완료/반려) 가능

## #️⃣연관된 이슈
> closed : #145

## 💬리뷰 요구사항(선택)
> 민원의 상태값은 '접수 대기' / '접수 완료' / '처리 중' / '처리 완료' / '반려' 총 5개를 가지고 현재는 등록과 동시에 '처리 중'
> 민원을 등록한 입주자는 '접수 대기' 상태에서만 삭제 가능
> 민원 관련 컨트롤러는 입주자와 소유자 동일한 엔드포인트 사용

* 입주자
    * 민원 등록 (호실->계약중인 호실 자동 지정, 내용)
    * 민원 목록 확인 가능
    * 민원 상태가 '접수 대기' 상태에서만 삭제 가능
* 소유자
    * 등록된 민원 확인 가능
    * 민원 내용에 따라 처리완료/반려 상태변경 처리와 메시지 입력 가능 (처리 메시지는 옵션으로 작성하지 않으면 기본 내용 들어감)

